### PR TITLE
v5.4.03

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -847,4 +847,7 @@ $sql[$count][1] = "";
 $sql[$count][0] = '5.4.02';
 $sql[$count][1] = "";
 
-
+//v5.4.03
+++$count;
+$sql[$count][0] = '5.4.03';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.4.03
+-------
+Fixed a file include error in the Parent dashboard
+
 v5.4.02
 -------
 Cleanup duplicate database connections, session_start and timezone_set

--- a/Free Learning/hook_parentalDashboard_unitHistory.php
+++ b/Free Learning/hook_parentalDashboard_unitHistory.php
@@ -20,16 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 $returnInt = null;
 
 //Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $_SESSION[$guid]['absolutePath'].'/modules/Free Learning/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/Free Learning/moduleFunctions.php';
-}
+require_once './modules/Free Learning/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitHistory_byStudent.php') == false) {
     //Acess denied

--- a/Free Learning/hook_studentDashboard_unitHistory.php
+++ b/Free Learning/hook_studentDashboard_unitHistory.php
@@ -20,16 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 $returnInt = null;
 
 //Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $_SESSION[$guid]['absolutePath'].'/modules/Free Learning/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/Free Learning/moduleFunctions.php';
-}
+require_once './modules/Free Learning/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitHistory_my.php') == false) {
     //Acess denied

--- a/Free Learning/hook_studentProfile_unitHistory.php
+++ b/Free Learning/hook_studentProfile_unitHistory.php
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/Free Learning/moduleFunctions.php';
+require_once './modules/Free Learning/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitHistory_byStudent.php') == false) {
     //Acess denied

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.4.02';
+$version = '5.4.03';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.4.02';
+$moduleVersion = '5.4.03';


### PR DESCRIPTION
Updates the dashboard hooks to use `require_once`, to fix an issue where moduleFunctions.php was being included more than once and causing a `Fatal error: Cannot redeclare getUnitList()`