### PR TITLE
v5.5.01

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -873,3 +873,8 @@ $sql[$count][0] = '5.5.00';
 $sql[$count][1] = "
 ALTER TABLE `freeLearningUnit` ADD `course` VARCHAR(50) NULL DEFAULT NULL AFTER `gibbonDepartmentIDList`;end
 ";
+
+//v5.5.01
+++$count;
+$sql[$count][0] = '5.5.01';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.5.01
+-------
+Updated TCPDF file include and font handling
+
 v5.5.00
 -------
 Added ability to group units by Course

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.5.00';
+$version = '5.5.01';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/units_browse_details_enrol_certificate.php
+++ b/Free Learning/units_browse_details_enrol_certificate.php
@@ -21,8 +21,12 @@ include '../../gibbon.php';
 
 include './moduleFunctions.php';
 
-$output = '';
+$tcpdfFile = '../../lib/tcpdf/tcpdf.php';
+if (is_file($tcpdfFile)) {
+    include $tcpdfFile;
+}
 
+$output = '';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
@@ -85,12 +89,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     }
 }
 
-//Setup for PDF
-include "../../lib/tcpdf/tcpdf.php";
-
 //Create PDF objects
 $pdf = new TCPDF ('P', 'mm', 'A4', true, 'UTF-8', false);
-$pdf->addTTFfont('DroidSansFallback');
+
+$fontFile = $_SESSION[$guid]['absolutePath']. '/resources/assets/fonts/DroidSansFallback.ttf';
+if (is_file($fontFile)) {
+    $pdf->addTTFfont($fontFile, 'TrueTypeUnicode', '', 32);
+} else {
+    $pdf->addTTFfont('DroidSansFallback');
+}
 
 $pdf->SetCreator($_SESSION[$guid]['organisationName']);
 $pdf->SetAuthor($_SESSION[$guid]['organisationName']);

--- a/Free Learning/units_browse_details_export.php
+++ b/Free Learning/units_browse_details_export.php
@@ -21,8 +21,12 @@ include '../../gibbon.php';
 
 include './moduleFunctions.php';
 
-$output = '';
+$tcpdfFile = '../../lib/tcpdf/tcpdf.php';
+if (is_file($tcpdfFile)) {
+    include $tcpdfFile;
+}
 
+$output = '';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
@@ -234,12 +238,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 //String replacements
 //$output = str_replace(array("<br>", "&#13;", "<br/>", "\n"), "<br />", $output);
 
-//Setup for PDF
-include "../../lib/tcpdf/tcpdf.php";
-
 //Create PDF objects
 $pdf = new TCPDF ('P', 'mm', 'A4', true, 'UTF-8', false);
-$pdf->addTTFfont('DroidSansFallback');
+$fontFile = $_SESSION[$guid]['absolutePath']. '/resources/assets/fonts/DroidSansFallback.ttf';
+if (is_file($fontFile)) {
+    $pdf->addTTFfont($fontFile, 'TrueTypeUnicode', '', 32);
+} else {
+    $pdf->addTTFfont('DroidSansFallback');
+}
 
 $pdf->SetCreator($_SESSION[$guid]['organisationName']);
 $pdf->SetAuthor($_SESSION[$guid]['organisationName']);

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.5.00';
+$moduleVersion = '5.5.01';


### PR DESCRIPTION
Updates Free Learning to be compatible for the changes in [#688](https://github.com/GibbonEdu/core/pull/688). Uses some `is_file` checks to aim to be backwards compatible, so you don't have to require v17 just yet.

Tested locally with v16 and v17.