### PR TITLE
v5.9.02

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -940,3 +940,8 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '5.9.01';
 $sql[$count][1] = "";
+
+//v5.9.02
+++$count;
+$sql[$count][0] = '5.9.02';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,14 @@
 CHANGELOG
 =========
+v5.9.02
+-------
+Updated filters in Current Unit by Class to have a My Classes section
+Limited Outcomes by Student/Unit History by Student to relevant students
+Filtered student enrolment by class to those in the same Learning Area
+Filtered dropdowns for Learning Area to only those used by Free Learning units
+Added a prerequisite check for students selecting collaborators to enrol with
+Fixed missing placeholder for Custom Field setting
+
 v5.9.01
 -------
 Improve the font size and display of content blocks in units

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -4,7 +4,7 @@ v5.9.02
 -------
 Updated filters in Current Unit by Class to have a My Classes section
 Limited Outcomes by Student/Unit History by Student to relevant students
-Filtered student enrolment by class to those in the same Learning Area
+Updated student enrolment by class to list classes in the same Learning Area at the top
 Filtered dropdowns for Learning Area to only those used by Free Learning units
 Added a prerequisite check for students selecting collaborators to enrol with
 Fixed missing placeholder for Custom Field setting

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.01';
+$version = '5.9.02';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/report_outcomes_byStudent.php
+++ b/Free Learning/report_outcomes_byStudent.php
@@ -50,8 +50,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         <optgroup label='--<?php echo __($guid, 'Students by Roll Group') ?>--'>
                             <?php
                             try {
-                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-                                $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name, surname, preferredName";
+                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
+                                        FROM freeLearningUnitStudent
+                                        JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID)
+                                        JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                                        JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+                                        JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                                        WHERE gibbonPerson.status='Full' 
+                                        AND (gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart<=:today) 
+                                        AND (gibbonPerson.dateEnd IS NULL  OR gibbonPerson.dateEnd>=:today) 
+                                        AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID 
+                                        GROUP BY gibbonPerson.gibbonPersonID, gibbonRollGroup.gibbonRollGroupID
+                                        ORDER BY gibbonYearGroup.sequenceNumber, gibbonRollGroup.name, gibbonPerson.surname, gibbonPerson.preferredName";
                                 $resultSelect = $connection2->prepare($sqlSelect);
                                 $resultSelect->execute($dataSelect);
                             } catch (PDOException $e) {
@@ -68,8 +79,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         <optgroup label='--<?php echo __($guid, 'Students by Name') ?>--'>
                             <?php
                             try {
-                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-                                $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY surname, preferredName";
+                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
+                                        FROM freeLearningUnitStudent
+                                        JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID) 
+                                        LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) 
+                                        LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) 
+                                        WHERE gibbonPerson.status='Full' 
+                                        AND (gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID OR gibbonRollGroup.gibbonSchoolYearID IS NULL) 
+                                        AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today) 
+                                        GROUP BY gibbonPerson.gibbonPersonID, gibbonRollGroup.gibbonRollGroupID
+                                        ORDER BY gibbonPerson.surname, gibbonPerson.preferredName";
                                 $resultSelect = $connection2->prepare($sqlSelect);
                                 $resultSelect->execute($dataSelect);
                             } catch (PDOException $e) {

--- a/Free Learning/report_unitHistory_byStudent.php
+++ b/Free Learning/report_unitHistory_byStudent.php
@@ -57,8 +57,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <option></option>
                                 <?php
                                 try {
-                                    $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
-                                    $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonStudentEnrolmentID, surname, preferredName, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.nameShort AS rollGroup FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonFamilyChild ON (gibbonPerson.gibbonPersonID=gibbonFamilyChild.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID AND childDataAccess='Y') WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPerson.status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY surname, preferredName";
+                                    $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'today' => date('Y-m-d'));
+                                    $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonStudentEnrolmentID, surname, preferredName, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.nameShort AS rollGroup FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonFamilyChild ON (gibbonPerson.gibbonPersonID=gibbonFamilyChild.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID AND childDataAccess='Y') WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPerson.status='Full' AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today) ORDER BY surname, preferredName";
                                     $resultSelect = $connection2->prepare($sqlSelect);
                                     $resultSelect->execute($dataSelect);
                                 } catch (PDOException $e) {
@@ -81,11 +81,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <optgroup label='--<?php echo __($guid, 'Students by Roll Group', 'Free Learning') ?>--'>
                                     <?php
                                     try {
-                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name, surname, preferredName";
+                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name 
+                                        FROM freeLearningUnitStudent
+                                        JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID)
+                                        JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                                        JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+                                        JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                                        WHERE gibbonPerson.status='Full' 
+                                        AND (gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart<=:today) 
+                                        AND (gibbonPerson.dateEnd IS NULL  OR gibbonPerson.dateEnd>=:today) 
+                                        AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID 
+                                        ORDER BY gibbonYearGroup.sequenceNumber, gibbonRollGroup.name, gibbonPerson.surname, gibbonPerson.preferredName";
                                         $resultSelect = $connection2->prepare($sqlSelect);
                                         $resultSelect->execute($dataSelect);
                                     } catch (PDOException $e) {
+                                        echo $e->getMessage();
                                     }
                             while ($rowSelect = $resultSelect->fetch()) {
                                 $selected = '';
@@ -99,8 +110,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <optgroup label='--<?php echo __($guid, 'All Users by Name', 'Free Learning') ?>--'>
                                     <?php
                                     try {
-                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name FROM gibbonPerson LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE status='Full' AND (gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID OR gibbonRollGroup.gibbonSchoolYearID IS NULL) AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY surname, preferredName";
+                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
+                                        FROM freeLearningUnitStudent
+                                        JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID) 
+                                        LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) 
+                                        LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) 
+                                        WHERE gibbonPerson.status='Full' 
+                                        AND (gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID OR gibbonRollGroup.gibbonSchoolYearID IS NULL) 
+                                        AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today) 
+                                        GROUP BY gibbonPerson.gibbonPersonID, gibbonRollGroup.gibbonRollGroupID
+                                        ORDER BY surname, preferredName";
                                         $resultSelect = $connection2->prepare($sqlSelect);
                                         $resultSelect->execute($dataSelect);
                                     } catch (PDOException $e) {

--- a/Free Learning/report_unitHistory_byStudent.php
+++ b/Free Learning/report_unitHistory_byStudent.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                     <?php
                                     try {
                                         $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
-                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name 
+                                        $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
                                         FROM freeLearningUnitStudent
                                         JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID)
                                         JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
@@ -92,6 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                         AND (gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart<=:today) 
                                         AND (gibbonPerson.dateEnd IS NULL  OR gibbonPerson.dateEnd>=:today) 
                                         AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID 
+                                        GROUP BY gibbonPerson.gibbonPersonID, gibbonRollGroup.gibbonRollGroupID
                                         ORDER BY gibbonYearGroup.sequenceNumber, gibbonRollGroup.name, gibbonPerson.surname, gibbonPerson.preferredName";
                                         $resultSelect = $connection2->prepare($sqlSelect);
                                         $resultSelect->execute($dataSelect);

--- a/Free Learning/settings_manage.php
+++ b/Free Learning/settings_manage.php
@@ -68,7 +68,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/settings_man
     $setting = $settingGateway->getSettingByScope('Free Learning', 'customField', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __m($setting['nameDisplay']))->description(__m($setting['description']));
-        $row->addSelect($setting['name'])->fromQuery($pdo, $sql)->selected($setting['value']);
+        $row->addSelect($setting['name'])->fromQuery($pdo, $sql)->selected($setting['value'])->placeholder();
 
     $form->addRow()->addHeading(__m('Enrolment Settings'));
 

--- a/Free Learning/src/Domain/UnitGateway.php
+++ b/Free Learning/src/Domain/UnitGateway.php
@@ -168,24 +168,29 @@ class UnitGateway extends QueryableGateway
     {
         if (!empty($gibbonPersonID)) {
             $data = ['gibbonPersonID' => $gibbonPersonID];
-            $sql = "(SELECT gibbonDepartmentID as value, name, 'Learning Area' as groupBy 
-                    FROM gibbonDepartment 
+            $sql = "(SELECT gibbonDepartment.gibbonDepartmentID as value, gibbonDepartment.name, 'Learning Area' as groupBy 
+                    FROM freeLearningUnit
+                    JOIN gibbonDepartment ON (FIND_IN_SET(gibbonDepartment.gibbonDepartmentID, freeLearningUnit.gibbonDepartmentIDList))
                     JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) 
-                    WHERE type='Learning Area' AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID 
+                    WHERE gibbonDepartment.type='Learning Area' AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID 
                     AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)')
-                    ORDER BY name)";
+                    GROUP BY gibbonDepartment.gibbonDepartmentID
+                    ORDER BY gibbonDepartment.name)";
         } else {
             $data = [];
-            $sql = "(SELECT gibbonDepartmentID as value, name, 'Learning Area' as groupBy 
-                    FROM gibbonDepartment WHERE type='Learning Area' 
-                    ORDER BY name)";
+            $sql = "(SELECT gibbonDepartment.gibbonDepartmentID as value, gibbonDepartment.name, 'Learning Area' as groupBy 
+                    FROM freeLearningUnit 
+                    JOIN gibbonDepartment ON (FIND_IN_SET(gibbonDepartment.gibbonDepartmentID, freeLearningUnit.gibbonDepartmentIDList))
+                    WHERE type='Learning Area' 
+                    GROUP BY gibbonDepartment.gibbonDepartmentID
+                    ORDER BY gibbonDepartment.name)";
         }
 
         $sql .= " UNION ALL 
         (SELECT DISTINCT course as value, course as name, 'Course' as groupBy FROM freeLearningUnit WHERE active='Y' AND NOT course IS NULL AND NOT course='' ORDER BY course)
         ORDER BY groupBy DESC, name";
 
-        return $this->db()->select($sql);
+        return $this->db()->select($sql, $data);
     }
 
     protected function getSharedFilterRules()

--- a/Free Learning/units_browse.php
+++ b/Free Learning/units_browse.php
@@ -225,6 +225,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                         }, $unit['authors'] ?? []);
 
                         $output = !empty($unit['learningArea']) ? '<div class="text-xs mb-2">'.$unit['learningArea'].'</div>' : '';
+                        $output .= !empty($unit['course']) && ($unit['learningArea'] != $unit['course']) ? '<div class="text-xs mb-2">'.$unit['course'].'</div>' : '';
                         $output .= '<div class="text-xxs">'.implode('<br/>', $unit['authors']).'</div>';
                         return $output;
                     });

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -165,10 +165,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 <span style="font-size: 90%"><i><?php echo __($guid, 'Which class are you enroling for?', 'Free Learning') ?></i></span>
                             </td>
                             <td class="right">
+                                
                                 <?php
                                 try {
-                                    $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
-                                    $sqlClasses = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse, gibbonCourseClass, gibbonCourseClassPerson WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND NOT role LIKE '% - Left%' ORDER BY course, class";
+                                    $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonDepartmentIDList' => $row['gibbonDepartmentIDList']);
+                                    $sqlClasses = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID 
+                                    FROM gibbonCourse
+                                    JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
+                                    JOIN gibbonCourseClassPerson ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID )
+                                    WHERE gibbonSchoolYearID=:gibbonSchoolYearID 
+                                    AND FIND_IN_SET(gibbonCourse.gibbonDepartmentID, :gibbonDepartmentIDList)
+                                    AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID 
+                                    AND NOT role LIKE '% - Left%' 
+                                    ORDER BY course, class";
                                     $resultClasses = $connection2->prepare($sqlClasses);
                                     $resultClasses->execute($dataClasses);
                                 } catch (PDOException $e) {

--- a/Free Learning/units_manage.php
+++ b/Free Learning/units_manage.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
         $form->setClass('noIntBorder fullWidth');
         $form->addHiddenValue('q', '/modules/Free Learning/units_manage.php');
     
-        $learningAreas = $unitGateway->selectLearningAreasAndCourses();
+        $learningAreas = $unitGateway->selectLearningAreasAndCourses($highestAction != 'Manage Units_all' ? $gibbon->session->get('gibbonPersonID') : null);
         $row = $form->addRow();
             $row->addLabel('gibbonDepartmentID', __('Learning Area & Course'));
             $row->addSelect('gibbonDepartmentID')->fromResults($learningAreas, 'groupBy')->selected($gibbonDepartmentID)->placeholder();

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.01';
+$moduleVersion = '5.9.02';


### PR DESCRIPTION
A number of usability fixes focused on filtering dropdown menus to only relevant options:

- Update filters in Current Unit by Class to have a My Classes section
- Limit Outcomes by Student/Unit History by Student to relevant students
- Filter student enrolment by class to those in the same Learning Area
- Filter dropdowns for Learning Area to only those used by Free Learning units
- Add a prerequisite check for students selecting collaborators to enrol with
- Fix missing placeholder for Custom Field setting

Be sure to test the prerequisite check for student collaborators, I've tested it a bunch but don't have as much data to work with. Thanks!