### PR TITLE
v5.9.04: Fix classes missing from dropdown in unit enrolment

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -950,3 +950,8 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '5.9.03';
 $sql[$count][1] = "";
+
+//v5.9.04
+++$count;
+$sql[$count][0] = '5.9.04';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.9.04
+-------
+Fixed classes missing from dropdown in unit enrolment 
+
 v5.9.03
 -------
 Improved filter persistence during submission

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.03';
+$version = '5.9.04';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -184,7 +184,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                     JOIN gibbonCourseClassPerson ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID )
                                     WHERE gibbonSchoolYearID=:gibbonSchoolYearID
                                     AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID
-                                    AND NOT FIND_IN_SET(gibbonCourse.gibbonDepartmentID, :gibbonDepartmentIDList)
+                                    AND (:gibbonDepartmentIDList = '' OR :gibbonDepartmentIDList IS NULL OR NOT FIND_IN_SET(gibbonCourse.gibbonDepartmentID, :gibbonDepartmentIDList))
                                     AND NOT role LIKE '% - Left%'
                                     ORDER BY course, class";
                                 $resultAllClasses = $pdo->select($sqlAllClasses, $dataClasses);

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.03';
+$moduleVersion = '5.9.04';


### PR DESCRIPTION
Fixes a bug where units with no learning area would have an empty dropdown for student courses.