### PR TITLE
v5.9.07 Fix the View As option in Browse Units

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -968,3 +968,9 @@ ALTER TABLE `freeLearningUnit` ADD `studentReflectionText` TEXT NULL AFTER `gibb
 $sql[$count][0] = '5.9.06';
 $sql[$count][1] = "
 ";
+
+//v5.9.07
+++$count;
+$sql[$count][0] = '5.9.07';
+$sql[$count][1] = "
+";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.9.07
+-------
+Fixed empty result set when using the View As option in Browse Units
+
 v5.9.06
 -------
 Fixed missing table field for studentReflectionText

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.06';
+$version = '5.9.07';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/units_browse.php
+++ b/Free Learning/units_browse.php
@@ -142,7 +142,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
         if ($highestAction == 'Browse Units_all' && !$viewingAsUser) {
             $units = $unitGateway->queryAllUnits($criteria, $gibbonPersonID, $publicUnits);
         } else {
-            $units = $unitGateway->queryUnitsByPrerequisites($criteria, $gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID, $roleCategory);
+            $units = $unitGateway->queryUnitsByPrerequisites($criteria, $gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID, !$viewingAsUser ? $roleCategory : '');
         }
 
         // Join a set of author data per unit

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.06';
+$moduleVersion = '5.9.07';


### PR DESCRIPTION
Just tripped across a bug (that I'm pretty sure I created during refactoring 😅), where the result set would come up empty when using the View As option in Browse Units.