### PR TITLE
v5.9.18

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1038,3 +1038,9 @@ $sql[$count][1] = "
 $sql[$count][0] = '5.9.17';
 $sql[$count][1] = "
 ";
+
+//v5.9.18
+++$count;
+$sql[$count][0] = '5.9.18';
+$sql[$count][1] = "
+";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.9.18
+-------
+Adjusted the status colours for units and added a legend to Browse Units
+
 v5.9.17
 -------
 Allowed students not currently enroled to see Free Learning in Student Dashboard

--- a/Free Learning/css/module.css
+++ b/Free Learning/css/module.css
@@ -17,10 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-.pending {
+.currentUnit {
     border-color: #B84EE4;
     background-color: #FDE2FF;
     color: #A93CB3;
+}
+
+.pending {
+    border-color: #78529e;
+    background-color: #dcc5f4;
+    color: #633f86;
 }
 
 .vis-tooltip {

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.17';
+$version = '5.9.18';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/report_workPendingApproval.php
+++ b/Free Learning/report_workPendingApproval.php
@@ -123,7 +123,7 @@ else {
 
     $table->addColumn('student', __('Student'))
         ->notSortable()
-        ->format(function($values) use ($guid) {
+        ->format(function($values) use ($guid, $customField) {
             $output = "";
             if ($values['category'] == 'Student') {
                 $output .= "<a href='index.php?q=/modules/Students/student_view_details.php&gibbonPersonID=" . $values["gibbonPersonID"] . "'>" . formatName("", $values["studentpreferredName"], $values["studentsurname"], "Student", true) . "</a>";

--- a/Free Learning/templates/unitLegend.twig.html
+++ b/Free Learning/templates/unitLegend.twig.html
@@ -1,0 +1,15 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+<div class="flex justify-start items-center mt-4">
+    <span class="text-xs mr-2">{{ __('Legend') }} : </span>
+    <span class="tag success mr-2">{{ __('Complete - Approved') }}</span>
+    <span class="tag currentUnit mr-2">{{ __('Current') }}</span>
+    <span class="tag pending mr-2">{{ __('Complete - Pending') }}</span>
+    <span class="tag warning mr-2">{{ __('Evidence Not Yet Approved') }}</span>
+</div>

--- a/Free Learning/units_browse.php
+++ b/Free Learning/units_browse.php
@@ -135,7 +135,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
         echo $templateView->fetchFromTemplate('unitButtons.twig.html', [
             'browseUnitsURL' => $browseUnitsURL,
             'publicUnits'    => $publicUnits,
-            'gibbonPersonID' => $gibbonPersonID,
+            'gibbonPersonID' => $gibbonPersonID
         ]);
 
         // QUERY
@@ -170,13 +170,13 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     $unit['statusClass'] = 'success';
                     break;
                 case 'Current':
-                    $unit['statusClass'] = 'warning';
+                    $unit['statusClass'] = 'currentUnit';
                     break;
                 case 'Complete - Pending':
                     $unit['statusClass'] = 'pending';
                     break;
                 case 'Evidence Not Yet Approved':
-                    $unit['statusClass'] = 'error';
+                    $unit['statusClass'] = 'warning';
                     break;
                 default:
                     $unit['statusClass']  = '';
@@ -381,11 +381,11 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     if ($unit['status'] == 'Complete - Approved' or $unit['status'] == 'Exempt') {
                         $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#390', background:'#D4F6DC'}, borderWidth: 2},";
                     } elseif ($unit['status'] == 'Current') {
-                        $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#D65602', background:'#FFD2A9'}, borderWidth: 2},";
-                    } elseif ($unit['status'] == 'Evidence Not Yet Approved') {
-                        $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#FF0000', background:'#FF8485'}, borderWidth: 2},";
-                    } elseif ($unit['status'] == 'Complete - Pending') {
                         $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#CA4AFF', background:'#F8A3FF'}, borderWidth: 2},";
+                    } elseif ($unit['status'] == 'Evidence Not Yet Approved') {
+                        $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#D65602', background:'#FFD2A9'}, borderWidth: 2},";
+                    } elseif ($unit['status'] == 'Complete - Pending') {
+                        $nodeList .= '{id: '.$countNodes.", shape: 'circularImage', image: 'undefined', label: '".addSlashes($unit['name'])."', title: '".$title."', color: {border:'#78529e', background:'#c6a5e8'}, borderWidth: 2},";
                     }
                     else {
                         if ($unit['freeLearningUnitIDPrerequisiteList'] == '') {
@@ -492,8 +492,9 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     });
                 </script>
                 <?php
-
             }
+
+            echo $templateView->fetchFromTemplate('unitLegend.twig.html');
         }
     }
 }

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -377,7 +377,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                             }
 
                             $table->modifyRows(function ($student, $row) {
-                                if ($student['status'] == 'Evidence Not Yet Approved') $row->addClass('error');
+                                if ($student['status'] == 'Evidence Not Yet Approved') $row->addClass('warning');
                                 if ($student['status'] == 'Complete - Pending') $row->addClass('pending');
                                 if ($student['status'] == 'Complete - Approved') $row->addClass('success');
                                 if ($student['status'] == 'Exempt') $row->addClass('success');

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.17';
+$moduleVersion = '5.9.18';


### PR DESCRIPTION
This PR adjusts some of the status colours used for units in the list/grid/map view. Specifically, it changes the red to orange for Evidence Not Yet Approved, and changes the Current and Pending statuses to lighter and darker shades of pink/purple, respectively. It also adds a legend to the list/grid/map view.

<img width="606" alt="Screen Shot 2020-04-22 at 9 48 37 AM" src="https://user-images.githubusercontent.com/897700/79932125-592c2600-847f-11ea-8f17-66e7e1a5126b.png">

<img width="466" alt="Screen Shot 2020-04-22 at 9 21 58 AM" src="https://user-images.githubusercontent.com/897700/79932152-6b0dc900-847f-11ea-80e2-742770c89181.png">

