### PR TITLE
v5.9.28 - Implement Discussion for Feedback

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1092,3 +1092,8 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '5.9.27';
 $sql[$count][1] = "";
+
+//v5.9.28
+++$count;
+$sql[$count][0] = '5.9.28';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.9.28
+-------
+Implemented the discussion table for feedback
+
 v5.9.27
 -------
 Relaxed student unit browsing to allow non-enrolled students

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.27';
+$version = '5.9.28';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -18,11 +18,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\View\View;
-use Gibbon\Tables\DataTable;
 use Gibbon\Domain\DataSet;
-use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\System\DiscussionGateway;
 use Gibbon\Module\FreeLearning\Domain\UnitGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
 
 // Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -399,22 +400,14 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                 return $row;
                             });
 
+                            $unitStudentGateway = $container->get(UnitStudentGateway::class);
                             $table->addExpandableColumn('commentStudent')
-                                ->format(function ($student) {
-                                    $output = '';
-                                    if (!empty($student['commentStudent'])) {
-                                        $output .= '<b>'.__m('Student Comment').'</b><br/>';
-                                        $output .= nl2br($student['commentStudent']).'<br/>';
-                                    }
-                                    if (!empty($student['commentApproval'])) {
-                                        if ($student['commentStudent'] != '') {
-                                            $output .= '<br/>';
-                                        }
-                                        $output .= '<b>'.__m('Teacher Comment').'</b><br/>';
-                                        $output .= nl2br($student['commentApproval']);
-                                    }
-
-                                    return $output;
+                                ->format(function ($student) use (&$page, &$unitStudentGateway) {
+                                    $logs = $unitStudentGateway->selectUnitStudentDiscussion($student['freeLearningUnitStudentID'])->fetchAll();
+                
+                                    return $page->fetchFromTemplate('ui/discussion.twig.html', [
+                                        'discussion' => $logs
+                                    ]);
                                 });
 
                             $table->addColumn('student', __('Student'))

--- a/Free Learning/units_browse_details_approval.php
+++ b/Free Learning/units_browse_details_approval.php
@@ -17,6 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\DiscussionGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
+
 // Module includes
 require_once __DIR__ . '/moduleFunctions.php';
 
@@ -354,12 +357,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 							</tr>
 							<tr>
 								<td colspan=2>
-									<b><?php echo __($guid, 'Student Comment', 'Free Learning') ?> *</b><br/>
-									<p>
-										<?php
-                                            echo $row['commentStudent'];
-                    					?>
-									</p>
+                                    <?php
+                                        $unitStudentGateway = $container->get(UnitStudentGateway::class);
+                                        $logs = $unitStudentGateway->selectUnitStudentDiscussion($freeLearningUnitStudentID)->fetchAll();
+                    
+                                        echo $page->fetchFromTemplate('ui/discussion.twig.html', [
+                                            'title' => __('Comments'),
+                                            'discussion' => $logs
+                                        ]);
+                                    ?>
 								</td>
 							</tr>
 
@@ -372,6 +378,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 							</tr>
 							<tr>
 								<td class="right" colspan=2>
+                                    <input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
 									<input type="hidden" name="freeLearningUnitStudentID" value="<?php echo $row['freeLearningUnitStudentID'] ?>">
 									<input type="hidden" name="freeLearningUnitID" value="<?php echo $freeLearningUnitID ?>">
 									<input type="submit" id="submit" value="Submit">

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.27';
+$moduleVersion = '5.9.28';


### PR DESCRIPTION
This PR updates the student and teacher comments to use the gibbonDiscussion table and template. Rather than a single field for comments, the full history of discussion is now saved, along with timestamps and status information. This enables displaying a discussion thread for any Free Learning submission:

<img width="760" alt="Screenshot 2020-08-28 at 2 57 57 PM" src="https://user-images.githubusercontent.com/897700/91531311-2b7c4f80-e93f-11ea-8377-e1b6a5148602.png">
