### PR TITLE
v5.10.0

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1107,3 +1107,10 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '5.9.30';
 $sql[$count][1] = "";
+
+//v5.9.31
+++$count;
+$sql[$count][0] = '5.9.31';
+$sql[$count][1] = "
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Evidence Submitted', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end
+";

--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1108,9 +1108,9 @@ $sql[$count][1] = "";
 $sql[$count][0] = '5.9.30';
 $sql[$count][1] = "";
 
-//v5.9.31
+//v5.10.00
 ++$count;
-$sql[$count][0] = '5.9.31';
+$sql[$count][0] = '5.10.00';
 $sql[$count][1] = "
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Evidence Submitted', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Unit Comment', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end

--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1113,4 +1113,6 @@ $sql[$count][1] = "";
 $sql[$count][0] = '5.9.31';
 $sql[$count][1] = "
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Evidence Submitted', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Unit Comment', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Unit Feedback', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end
 ";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,8 +1,12 @@
 CHANGELOG
 =========
-v5.9.31
+v5.10.00
 -------
+Added the ability for students and mentors to comment on units
 Enabled parents viewing their children's units on the map view
+Fixed collaborative submissions for external mentorship
+Updated external mentorship emails to use an email template
+Ooified the Enrol tab and Mentorship forms
 
 v5.9.30
 -------

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.9.31
+-------
+Enabled parents viewing their children's units on the map view
+
 v5.9.30
 -------
 Added an edit icon to the Work Pending Approval page

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.30';
+$version = '5.9.31';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 
@@ -147,6 +147,7 @@ $gibbonSetting[6] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`n
 $gibbonSetting[7] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Free Learning', 'enableExternalMentorEnrolment', 'Enable External Mentor Enrolment', 'Should external mentor enrolment be an option for learners?', 'N');";
 $gibbonSetting[8] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Free Learning', 'customField', 'Custom Field', 'A user custom field to display under student names in Manage Enrolment.', '');";
 $gibbonSetting[9] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Free Learning', 'collaborativeAssessment', 'Collaborative Assessment', 'Should students be working together submit and assess together?', 'N');";
+$gibbonSetting[10] = "INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Evidence Submitted', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end";
 
 //Action rows
 $actionRows[0]['name'] = 'Manage Units_all';

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.9.31';
+$version = '5.10.00';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 
@@ -148,6 +148,9 @@ $gibbonSetting[7] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`n
 $gibbonSetting[8] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Free Learning', 'customField', 'Custom Field', 'A user custom field to display under student names in Manage Enrolment.', '');";
 $gibbonSetting[9] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Free Learning', 'collaborativeAssessment', 'Collaborative Assessment', 'Should students be working together submit and assess together?', 'N');";
 $gibbonSetting[10] = "INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Evidence Submitted', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end";
+$gibbonSetting[11] = "INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Unit Comment', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end";
+$gibbonSetting[12] = "INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Unit Feedback', 'Free Learning', 'Browse Units_all', 'Additional', 'All', 'Y');end";
+
 
 //Action rows
 $actionRows[0]['name'] = 'Manage Units_all';

--- a/Free Learning/report_currentUnitByClass.php
+++ b/Free Learning/report_currentUnitByClass.php
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_curre
                 }
                 echo '</td>';
                 echo '<td>';
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&freeLearningUnitID='.$row['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='>".htmlPrep($row['unitName']).'</a>';
+                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&tab=2&freeLearningUnitID='.$row['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='>".htmlPrep($row['unitName']).'</a>';
                 echo "<br/><span style='font-size: 85%; font-style: italic'>".$row['status'].'</span>';
                 echo '</td>';
                 echo '<td>';

--- a/Free Learning/src/Domain/UnitStudentGateway.php
+++ b/Free Learning/src/Domain/UnitStudentGateway.php
@@ -181,14 +181,16 @@ class UnitStudentGateway extends QueryableGateway
                 ->from('freeLearningUnitStudent')
                 ->innerJoin('gibbonPerson', 'freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID')
                 ->where('freeLearningUnitStudent.freeLearningUnitStudentID = :freeLearningUnitStudentID')
-                ->bindValue('freeLearningUnitStudentID', $freeLearningUnitStudentID);
+                ->bindValue('freeLearningUnitStudentID', $freeLearningUnitStudentID)
+                ->where('commentStudent IS NOT NULL');
 
             $query->union()
                 ->cols(['freeLearningUnitStudent.commentApproval as comment', 'freeLearningUnitStudent.status as type', "(CASE WHEN freeLearningUnitStudent.status = 'Complete - Pending' THEN 'pending' WHEN freeLearningUnitStudent.status = 'Evidence Not Yet Approved' THEN 'warning' WHEN freeLearningUnitStudent.status = 'Complete - Approved' THEN 'success' ELSE 'dull' END) as tag", 'gibbonPerson.gibbonPersonID', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.image_240',  'timestampCompleteApproved as timestamp'])
                 ->from('freeLearningUnitStudent')
                 ->innerJoin('gibbonPerson', 'freeLearningUnitStudent.gibbonPersonIDApproval=gibbonPerson.gibbonPersonID')
                 ->where('freeLearningUnitStudent.freeLearningUnitStudentID = :freeLearningUnitStudentID')
-                ->bindValue('freeLearningUnitStudentID', $freeLearningUnitStudentID);
+                ->bindValue('freeLearningUnitStudentID', $freeLearningUnitStudentID)
+                ->where('commentApproval IS NOT NULL');
 
             $result = $this->runSelect($query);
         }

--- a/Free Learning/src/Domain/UnitStudentGateway.php
+++ b/Free Learning/src/Domain/UnitStudentGateway.php
@@ -159,7 +159,7 @@ class UnitStudentGateway extends QueryableGateway
         return $this->runSelect($query)->fetch();
     }
 
-    public function selectUnitStudentDiscussion($freeLearningUnitStudentID, $includeMentor = false)
+    public function selectUnitStudentDiscussion($freeLearningUnitStudentID)
     {
         $query = $this
             ->newSelect()

--- a/Free Learning/templates/mentorRequest.twig.html
+++ b/Free Learning/templates/mentorRequest.twig.html
@@ -1,0 +1,34 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{{ __('To whom it may concern,') }}
+
+<p>
+    {{ __('The following %1$s at %2$s has requested your input into their %3$sFree Learning%4$s work, with the hope that you will be able to act as a "critical buddy" or mentor, offering feedback on their progress.', {'%1$s': roleCategoryFull, '%2$s': organisationNameShort, '%3$s': "<a target='_blank' href='http://rossparker.org'>", '%4$s': '</a>'} )|raw }}
+</p>
+
+
+<ul>
+    {% for student in students %}
+    <li>{{ student[0] }}</li>
+    {% endfor %}
+</ul>
+
+<p>
+    {{ __('The unit you are being asked to advise on is called %1$s and is described as follows:', {'%1$s': '<b>' ~ unitName  ~ '</b>'})|raw }}<br/><br/>
+    
+    <i>{{ unitBlurb }}</i>
+</p>
+
+<p>
+    {{ __('Please click the buttons below to indicate whether or not you are able to get involved.') }}
+</p>
+
+<p>
+    {{ __('Thank you very much for your time. Should you have any questions about this matter, please reply to this email, or contact %1$s on %2$s.', {'%1$s': organisationAdministratorName, '%2$s': organisationAdministratorEmail}) }}
+</p>

--- a/Free Learning/templates/mentorSubmit.twig.html
+++ b/Free Learning/templates/mentorSubmit.twig.html
@@ -1,0 +1,25 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{{ __('To whom it may concern,') }}
+
+<p>
+    {{ __('The following %1$s at %2$s has requested your feedback on their %3$sFree Learning%4$s work (%5$s), which they have just submitted, and on which you previously agreed to mentor them.', {'%1$s': roleCategoryFull, '%2$s': organisationNameShort, '%3$s': "<a target='_blank' href='http://rossparker.org'>", '%4$s': '</a>', '%5$s': unitName} )|raw }}
+</p>
+
+<ul>
+    <li>{{ studentName }}</li>
+</ul>
+
+<p>
+    {{ __('Please click the button below to view and give feedback on the submitted work.') }}
+</p>
+
+<p>
+    {{ __('Thank you very much for your time. Should you have any questions about this matter, please reply to this email, or contact %1$s on %2$s.', {'%1$s': organisationAdministratorName, '%2$s': organisationAdministratorEmail}) }}
+</p>

--- a/Free Learning/units_browse.php
+++ b/Free Learning/units_browse.php
@@ -130,10 +130,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
         } elseif ($roleCategory == 'Parent') {
             // Allow parents to view the map for their children
             $children = $container->get(StudentGateway::class)->selectActiveStudentsByFamilyAdult($_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'])->fetchAll();
-            $children = array_reduce($children, function ($group, $item) {
-                $group[$item['gibbonPersonID']] = Format::name($item['title'], $item['preferredName'], $item['surname'], 'Student', false, true);
-                return $group;
-            }, []);
+            $children = Format::nameListArray($children, 'Student', false, true);
 
             if (empty($children[$gibbonPersonID])) {
                 $gibbonPersonID = null;

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -104,7 +104,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                 echo __($guid, 'The selected record does not exist, or you do not have access to it.');
                 echo '</div>';
             } else {
-                $row = $result->fetch();
+                $values = $result->fetch();
                 if ($gibbonDepartmentID != '' or $difficulty != '' or $name != '') {
                     echo "<div class='linkTop'>";
                     echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_browse.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view'>".__($guid, 'Back to Search Results', 'Free Learning').'</a>';
@@ -115,10 +115,10 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                 if ($highestAction == 'Browse Units_all') {
                     $proceed = true;
                 } elseif ($highestAction == 'Browse Units_prerequisites') {
-                    if ($row['freeLearningUnitIDPrerequisiteList'] == null or $row['freeLearningUnitIDPrerequisiteList'] == '') {
+                    if ($values['freeLearningUnitIDPrerequisiteList'] == null or $values['freeLearningUnitIDPrerequisiteList'] == '') {
                         $proceed = true;
                     } else {
-                        $prerequisitesActive = prerequisitesRemoveInactive($connection2, $row['freeLearningUnitIDPrerequisiteList']);
+                        $prerequisitesActive = prerequisitesRemoveInactive($connection2, $values['freeLearningUnitIDPrerequisiteList']);
                         $prerequisitesMet = prerequisitesMet($connection2, $gibbonPersonID, $prerequisitesActive);
                         if ($prerequisitesMet) {
                             $proceed = true;
@@ -169,7 +169,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
                     echo '<tr>';
                     echo "<td style='width: 50%; vertical-align: middle'>";
-                    echo "<span style='font-size: 150%; font-weight: bold'>".$row['name'].'</span><br/>';
+                    echo "<span style='font-size: 150%; font-weight: bold'>".$values['name'].'</span><br/>';
                     echo '</td>';
                     echo "<td style='width: 50%; vertical-align: top'>";
                     echo "<span style='font-size: 115%; font-weight: bold'>".__($guid, 'Time', 'Free Learning').'</span><br/>';
@@ -177,7 +177,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     $blocks = getBlocksArray($connection2, $freeLearningUnitID);
                     if ($blocks != false) {
                         foreach ($blocks as $block) {
-                            if ($block[0] == $row['freeLearningUnitID']) {
+                            if ($block[0] == $values['freeLearningUnitID']) {
                                 if (is_numeric($block[2])) {
                                     $timing += $block[2];
                                 }
@@ -191,21 +191,21 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     }
                     echo '</td>';
                     echo "<td style='width: 135%!important; vertical-align: top; text-align: right' rowspan=4>";
-                    if ($row['logo'] == null) {
+                    if ($values['logo'] == null) {
                         echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_125.jpg'/><br/>";
                     } else {
-                        echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$row['logo']."'/><br/>";
+                        echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$values['logo']."'/><br/>";
                     }
                     echo '</td>';
                     echo '</tr>';
                     echo '<tr>';
                     echo "<td style='padding-top: 15px; vertical-align: top'>";
                     echo "<span style='font-size: 115%; font-weight: bold'>".__($guid, 'Difficulty', 'Free Learning').'</span><br/>';
-                    echo '<i>'.$row['difficulty'].'<i>';
+                    echo '<i>'.$values['difficulty'].'<i>';
                     echo '</td>';
                     echo "<td style='padding-top: 15px; vertical-align: top'>";
                     echo "<span style='font-size: 115%; font-weight: bold'>".__($guid, 'Prerequisites', 'Free Learning').'</span><br/>';
-                    $prerequisitesActive = prerequisitesRemoveInactive($connection2, $row['freeLearningUnitIDPrerequisiteList']);
+                    $prerequisitesActive = prerequisitesRemoveInactive($connection2, $values['freeLearningUnitIDPrerequisiteList']);
                     if ($prerequisitesActive != false) {
                         $prerequisites = explode(',', $prerequisitesActive);
                         $units = getUnitsArray($connection2);
@@ -225,7 +225,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                         echo '<i>'.__($guid, 'No Learning Areas available.', 'Free Learning').'</i>';
                     } else {
                         for ($i = 0; $i < count($learningAreas); $i = $i + 2) {
-                            if (is_numeric(strpos($row['gibbonDepartmentIDList'], $learningAreas[$i]))) {
+                            if (is_numeric(strpos($values['gibbonDepartmentIDList'], $learningAreas[$i]))) {
                                 echo '<i>'.__($guid, $learningAreas[($i + 1)]).'</i><br/>';
                             }
                         }
@@ -246,8 +246,8 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     echo '<tr>';
                     echo "<td style='vertical-align: top'>";
                     echo "<span style='font-size: 115%; font-weight: bold'>".__($guid, 'Groupings', 'Free Learning').'</span><br/>';
-                    if ($row['grouping'] != '') {
-                        $groupings = explode(',', $row['grouping']);
+                    if ($values['grouping'] != '') {
+                        $groupings = explode(',', $values['grouping']);
                         foreach ($groupings as $grouping) {
                             echo ucwords($grouping).'<br/>';
                         }
@@ -299,22 +299,22 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     echo __($guid, 'Blurb', 'Free Learning');
                     echo '</h3>';
                     echo '<p>';
-                    echo $row['blurb'];
+                    echo $values['blurb'];
                     echo '</p>';
-                    if ($row['license'] != '') {
+                    if ($values['license'] != '') {
                         echo '<h4>';
                         echo __($guid, 'License', 'Free Learning');
                         echo '</h4>';
                         echo '<p>';
-                        echo __($guid, 'This work is shared under the following license:', 'Free Learning').' '.$row['license'];
+                        echo __($guid, 'This work is shared under the following license:', 'Free Learning').' '.$values['license'];
                         echo '</p>';
                     }
-                    if ($row['outline'] != '') {
+                    if ($values['outline'] != '') {
                         echo '<h3>';
                         echo 'Outline';
                         echo '</h3>';
                         echo '<p>';
-                        echo $row['outline'];
+                        echo $values['outline'];
                         echo '</p>';
                     }
                     echo '</div>';
@@ -336,7 +336,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                 $learningAreas = getLearningAreas($connection2, $guid, true);
                                 if ($learningAreas != '') {
                                     for ($i = 0; $i < count($learningAreas); $i = $i + 2) {
-                                        if (is_numeric(strpos($row['gibbonDepartmentIDList'], $learningAreas[$i]))) {
+                                        if (is_numeric(strpos($values['gibbonDepartmentIDList'], $learningAreas[$i]))) {
                                             $enrolmentType = 'staffEdit';
                                         }
                                     }
@@ -363,7 +363,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                 ->sortBy(['statusSort', 'collaborationKey', 'surname', 'preferredName'])
                                 ->fromPOST();
 
-                            $students = $unitStudentGateway->queryCurrentStudentsByUnit($criteria, $gibbon->session->get('gibbonSchoolYearID'), $row['freeLearningUnitID'], $gibbon->session->get('gibbonPersonID'), $manageAll);
+                            $students = $unitStudentGateway->queryCurrentStudentsByUnit($criteria, $gibbon->session->get('gibbonSchoolYearID'), $values['freeLearningUnitID'], $gibbon->session->get('gibbonPersonID'), $manageAll);
                             $canViewStudents = isActionAccessible($guid, $connection2, '/modules/Students/student_view_details.php');
                             $customField = getSettingByScope($connection2, 'Free Learning', 'customField');
 
@@ -379,7 +379,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                             if ($enrolmentType == 'staffEdit') {
                                 $table->addHeaderAction('addMultiple', __('Add Multiple'))
                                     ->setURL('/modules/Free Learning/units_browse_details_enrolMultiple.php')
-                                    ->addParam('freeLearningUnitID', $row['freeLearningUnitID'])
+                                    ->addParam('freeLearningUnitID', $values['freeLearningUnitID'])
                                     ->addParam('gibbonDepartmentID', $gibbonDepartmentID)
                                     ->addParam('difficulty', $difficulty)
                                     ->addParam('name', $name)

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -555,9 +555,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     $blocks = $pdo->select($sqlBlocks, $dataBlocks)->fetchAll();
 
                     if (empty($blocks)) {
-                        echo "<div class='error'>";
-                        echo __('There are no records to display.');
-                        echo '</div>';
+                        echo Format::alert(__('There are no records to display.'));
                     } else {
                         $templateView = $container->get(View::class);
                         $resourceContents = '';
@@ -565,7 +563,9 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                         $blockCount = 0;
                         foreach ($blocks as $block) {
                             echo $templateView->fetchFromTemplate('unitBlock.twig.html', $block + [
-                                'roleCategory' => $roleCategory, 'gibbonPersonID' => $_SESSION[$guid]['username'] ?? '', 'blockCount' => $blockCount
+                                'roleCategory' => $roleCategory,
+                                'gibbonPersonID' => $_SESSION[$guid]['username'] ?? '',
+                                'blockCount' => $blockCount
                             ]);
                             $resourceContents .= $block['contents'];
                             $blockCount++;

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -515,7 +515,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                     }
 
                                     if ($enrolmentType == 'staffEdit' || $editEnrolment) {
-                                        if ($editEnrolment && ($student['status'] == 'Complete - Pending' or $student['status'] == 'Complete - Approved' or $student['status'] == 'Evidence Not Yet Approved')) {
+                                        if ($editEnrolment && ($student['status'] == 'Current' || $student['status'] == 'Complete - Pending' or $student['status'] == 'Complete - Approved' or $student['status'] == 'Evidence Not Yet Approved')) {
                                             $actions->addAction('edit', __('Edit'))
                                                 ->setURL('/modules/Free Learning/units_browse_details_approval.php');
                                         }

--- a/Free Learning/units_browse_details_approval.php
+++ b/Free Learning/units_browse_details_approval.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     }
 
     // Check that the record exists
-    $values = $unitStudentGateway->getUnitStudentDetailsByID($freeLearningUnitID, $freeLearningUnitStudentID);
+    $values = $unitStudentGateway->getUnitStudentDetailsByID($freeLearningUnitID, null, $freeLearningUnitStudentID);
     if (empty($values)) {
         $page->addError(__('The selected record does not exist, or you do not have access to it.'));
         return;
@@ -180,7 +180,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 
     $row = $form->addRow();
         $row->addLabel('submission', __m('Submission'));
-        $row->addContent(Format::link($submissionLink, __m('View Submission'), ['class' => 'w-full ml-2', 'target' => '_blank']));
+        $row->addContent(Format::link($submissionLink, __m('View Submission'), ['class' => 'w-full ml-2 underline', 'target' => '_blank']));
     
     $unitStudentGateway = $container->get(UnitStudentGateway::class);
     $logs = $unitStudentGateway->selectUnitStudentDiscussion($freeLearningUnitStudentID)->fetchAll();

--- a/Free Learning/units_browse_details_approval.php
+++ b/Free Learning/units_browse_details_approval.php
@@ -203,13 +203,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 
     $row = $form->addRow();
         $row->addLabel('status', __('Status'));
-        $row->addSelect('status')->fromArray($statuses)->required()->placeholder();
+        $row->addSelect('status')->fromArray($statuses)->required()->placeholder()->selected($values['status']);
 
     $form->toggleVisibilityByClass('exemplar')->onSelect('status')->when('Complete - Approved');
 
     $row = $form->addRow()->addClass('exemplar');
         $row->addLabel('exemplarWork', __m('Exemplar Work'))->description(__m('Work and comments will be made viewable to other users.'));
-        $row->addYesNo('exemplarWork')->required()->selected('N');
+        $row->addYesNo('exemplarWork')->required()->selected($values['exemplarWork'] ?? 'N');
 
     $form->toggleVisibilityByClass('exemplarYes')->onSelect('exemplarWork')->when('Y');
 
@@ -221,11 +221,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 
     $row = $form->addRow()->addClass('exemplarYes');
         $row->addLabel('exemplarWorkLicense', __m('Exemplar Work Thumbnail Image Credit'))->description(__m('Credit and license for image used above.'));
-        $row->addTextField('exemplarWorkLicense')->maxLength(255);
+        $row->addTextField('exemplarWorkLicense')->maxLength(255)->setValue($values['exemplarWorkLicense']);
 
     $row = $form->addRow()->addClass('exemplarYes');
         $row->addLabel('exemplarWorkEmbed', __m('Exemplar Work Embed'))->description(__m('Include embed code, otherwise link to work will be used.'));
-        $row->addTextField('exemplarWorkLicense')->maxLength(255);
+        $row->addTextField('exemplarWorkEmbed')->maxLength(255)->setValue($values['exemplarWorkEmbed']);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/Free Learning/units_browse_details_commentProcess.php
+++ b/Free Learning/units_browse_details_commentProcess.php
@@ -1,0 +1,124 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\System\DiscussionGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitGateway;
+use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
+
+require_once '../../gibbon.php';
+
+$freeLearningUnitID = $_POST['freeLearningUnitID'] ?? '';
+$freeLearningUnitStudentID = $_POST['freeLearningUnitStudentID'] ?? '';
+$gibbonPersonID = $_POST['gibbonPersonID'] ?? $gibbon->session->get('gibbonPersonID');
+$comment = $_POST['addComment'] ?? '';
+
+$urlParams = [
+    'freeLearningUnitStudentID' => $freeLearningUnitStudentID,
+    'freeLearningUnitID'        => $freeLearningUnitID,
+    'showInactive'              => $_GET['showInactive'] ?? 'N',
+    'gibbonDepartmentID'        => $_GET['gibbonDepartmentID'] ?? '',
+    'difficulty'                => $_GET['difficulty'] ?? '',
+    'name'                      => $_GET['name'] ?? '',
+    'view'                      => $_GET['view'] ?? '',
+    'sidebar'                   => 'true',
+    'gibbonPersonID'            => $gibbonPersonID,
+];
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&&tab=1&'.http_build_query($urlParams);
+
+if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $unitGateway = $container->get(UnitGateway::class);
+    $unitStudentGateway = $container->get(UnitStudentGateway::class);
+    $discussionGateway = $container->get(DiscussionGateway::class);
+    $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
+
+    // Validate the required values
+    if (empty($freeLearningUnitID) || empty($freeLearningUnitStudentID) || empty($comment)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate the record exists
+    $unit = $unitGateway->getByID($freeLearningUnitID);
+    $values = $unitStudentGateway->getByID($freeLearningUnitStudentID);
+    if (empty($values) || empty($unit)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Insert discussion records        
+    $data = [
+        'foreignTable'       => 'freeLearningUnitStudent',
+        'foreignTableID'     => $freeLearningUnitStudentID,
+        'gibbonModuleID'     => getModuleIDFromName($connection2, 'Free Learning'),
+        'gibbonPersonID'     => $gibbon->session->get('gibbonPersonID'),
+        'comment'            => $comment,
+        'type'               => 'Comment',
+        'tag'                => 'dull',
+    ];
+
+    if ($collaborativeAssessment == 'Y' AND !empty($values['collaborationKey'])) {
+        $collaborators = $unitStudentGateway->selectBy(['collaborationKey' => $values['collaborationKey']])->fetchAll();
+        foreach ($collaborators as $collaborator) {
+            $data['foreignTableID'] = $collaborator['freeLearningUnitStudentID'];
+            $discussionGateway->insert($data);
+        }
+    } else {
+        $discussionGateway->insert($data);
+    }
+
+    // Raise a new notification event
+    $event = new NotificationEvent('Free Learning', 'Evidence Submitted');
+    $event->addScope('gibbonPersonIDStudent', $values['gibbonPersonIDStudent']);
+    $event->setNotificationText(sprintf(__m('A student has added a comment to their current unit (%1$s).'), $unit['name']));
+    $event->setActionLink("/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&sidebar=true&tab=2");
+
+    if ($values['enrolmentMethod'] == 'class') { 
+        // Attempt to notify teacher(s) of class
+        $courseGateway = $container->get(CourseEnrolmentGateway::class);
+        $teachers = $courseGateway->selectClassTeachersByStudent($gibbon->session->get('gibbonSchoolYearID'), $values['gibbonPersonIDStudent'], $values['gibbonCourseClassID'])->fetchAll();
+
+        foreach ($teachers as $teacher) {
+            $event->addRecipient($teacher['gibbonPersonID']);
+        }
+    } elseif ($values['enrolmentMethod'] == 'schoolMentor' && !empty($values['gibbonPersonIDSchoolMentor'])) { 
+        // Attempt to notify school mentor
+        $event->addRecipient($teacher['gibbonPersonIDSchoolMentor']);
+
+    } elseif ($values['enrolmentMethod'] == 'externalMentor' && !empty($values['emailExternalMentor'])) { 
+        // Attempt to notify external mentors
+
+        // TODO
+    }
+
+    // Send any notifications
+    $event->sendNotifications($pdo, $gibbon->session);
+
+    $URL .= "&return=success0";
+    header("Location: {$URL}");
+    exit;
+}

--- a/Free Learning/units_browse_details_commentProcess.php
+++ b/Free Learning/units_browse_details_commentProcess.php
@@ -120,10 +120,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             // Attempt to notify school mentor
             $event->addRecipient($teacher['gibbonPersonIDSchoolMentor']);
 
-        } elseif ($values['enrolmentMethod'] == 'externalMentor' && !empty($values['emailExternalMentor'])) { 
-            // Attempt to notify external mentors
-
-            // TODO
+        } elseif ($values['enrolmentMethod'] == 'externalMentor') { 
+            // Not available through the Mentor interface
         }
     }
 

--- a/Free Learning/units_browse_details_commentProcess.php
+++ b/Free Learning/units_browse_details_commentProcess.php
@@ -42,7 +42,7 @@ $urlParams = [
     'gibbonPersonID'            => $gibbonPersonID,
 ];
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&&tab=1&'.http_build_query($urlParams);
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&tab=1&'.http_build_query($urlParams);
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false) {
     $URL .= '&return=error0';
@@ -53,6 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     $unitStudentGateway = $container->get(UnitStudentGateway::class);
     $discussionGateway = $container->get(DiscussionGateway::class);
     $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
+    $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
 
     // Validate the required values
     if (empty($freeLearningUnitID) || empty($freeLearningUnitStudentID) || empty($comment)) {
@@ -92,27 +93,38 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     }
 
     // Raise a new notification event
-    $event = new NotificationEvent('Free Learning', 'Evidence Submitted');
-    $event->addScope('gibbonPersonIDStudent', $values['gibbonPersonIDStudent']);
-    $event->setNotificationText(sprintf(__m('A student has added a comment to their current unit (%1$s).'), $unit['name']));
-    $event->setActionLink("/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&sidebar=true&tab=2");
+    $event = new NotificationEvent('Free Learning', 'Unit Comment');
+    
+    $canManage = isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php');
+    if ($canManage && $roleCategory != 'Student') {
+        $event->setNotificationText(sprintf(__m('A teacher has added a comment to your current unit (%1$s).'), $unit['name']));
+        $event->setActionLink("/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&sidebar=true&tab=1");
+        $event->addRecipient($values['gibbonPersonIDStudent']);
 
-    if ($values['enrolmentMethod'] == 'class') { 
-        // Attempt to notify teacher(s) of class
-        $courseGateway = $container->get(CourseEnrolmentGateway::class);
-        $teachers = $courseGateway->selectClassTeachersByStudent($gibbon->session->get('gibbonSchoolYearID'), $values['gibbonPersonIDStudent'], $values['gibbonCourseClassID'])->fetchAll();
+        $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details_approval.php&'.http_build_query($urlParams);
 
-        foreach ($teachers as $teacher) {
-            $event->addRecipient($teacher['gibbonPersonID']);
+    } else {
+        $event->addScope('gibbonPersonIDStudent', $values['gibbonPersonIDStudent']);
+        $event->setNotificationText(sprintf(__m('A student has added a comment to their current unit (%1$s).'), $unit['name']));
+        $event->setActionLink("/index.php?q=/modules/Free Learning/units_browse_details_approval.php&freeLearningUnitID=$freeLearningUnitID&freeLearningUnitStudentID=$freeLearningUnitStudentID&sidebar=true");
+
+        if ($values['enrolmentMethod'] == 'class') { 
+            // Attempt to notify teacher(s) of class
+            $courseGateway = $container->get(CourseEnrolmentGateway::class);
+            $teachers = $courseGateway->selectClassTeachersByStudent($gibbon->session->get('gibbonSchoolYearID'), $values['gibbonPersonIDStudent'], $values['gibbonCourseClassID'])->fetchAll();
+
+            foreach ($teachers as $teacher) {
+                $event->addRecipient($teacher['gibbonPersonID']);
+            }
+        } elseif ($values['enrolmentMethod'] == 'schoolMentor' && !empty($values['gibbonPersonIDSchoolMentor'])) { 
+            // Attempt to notify school mentor
+            $event->addRecipient($teacher['gibbonPersonIDSchoolMentor']);
+
+        } elseif ($values['enrolmentMethod'] == 'externalMentor' && !empty($values['emailExternalMentor'])) { 
+            // Attempt to notify external mentors
+
+            // TODO
         }
-    } elseif ($values['enrolmentMethod'] == 'schoolMentor' && !empty($values['gibbonPersonIDSchoolMentor'])) { 
-        // Attempt to notify school mentor
-        $event->addRecipient($teacher['gibbonPersonIDSchoolMentor']);
-
-    } elseif ($values['enrolmentMethod'] == 'externalMentor' && !empty($values['emailExternalMentor'])) { 
-        // Attempt to notify external mentors
-
-        // TODO
     }
 
     // Send any notifications

--- a/Free Learning/units_browse_details_completePendingProcess.php
+++ b/Free Learning/units_browse_details_completePendingProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\View\View;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\System\DiscussionGateway;
 use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
@@ -120,8 +121,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                     $row = $result->fetch();
                     $name = $row['name'];
                     $confirmationKey = $row['confirmationKey'];
-                    $student[0] = formatName('', $row['preferredName'], $row['surname'], 'Student', true);
-                    $student[1] = $row['email'];
+                    $studentName = formatName('', $row['preferredName'], $row['surname'], 'Student', true);
+                    $studentEmail = $row['email'];
                     $enrolmentMethod = $row['enrolmentMethod'];
                     $gibbonPersonIDSchoolMentor = $row['gibbonPersonIDSchoolMentor'];
                     $emailExternalMentor = $row['emailExternalMentor'];
@@ -250,58 +251,41 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                             }
                             else if ($enrolmentMethod == 'schoolMentor' && $gibbonPersonIDSchoolMentor != '') { //Attempt to notify school mentor
                                 $text = sprintf(__($guid, 'A student has requested unit completion approval and feedback (%1$s).', 'Free Learning'), $name);
-                                $actionLink = "/index.php?q=/modules/Free Learning/units_mentor_approval.php&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey";
+                                $actionLink = "/index.php?q=/modules/Free Learning/units_mentor_approval.php&freeLearningUnitStudentID=$freeLearningUnitStudentID&confirmationKey=$confirmationKey";
                                 setNotification($connection2, $guid, $gibbonPersonIDSchoolMentor, $text, 'Free Learning', $actionLink);
                             }
-                            elseif ($enrolmentMethod == 'externalMentor' && $emailExternalMentor != '') { //Attempt to notify external mentors
-                                $mailFile = '../../lib/PHPMailer/PHPMailerAutoload.php';
-                                if (is_file($mailFile)) {
-                                    include $mailFile;
-                                }
+                            elseif ($enrolmentMethod == 'externalMentor' && $emailExternalMentor != '') { 
+                                // Attempt to notify external mentors
+                                
+                                $subject = sprintf(__m('Request For Mentor Feedback via %1$s at %2$s'), $gibbon->session->get('systemName'), $gibbon->session->get('organisationNameShort'));
+                                $buttonURL = "/index.php?q=/modules/Free Learning/units_mentor_approval.php&freeLearningUnitStudentID=$freeLearningUnitStudentID&confirmationKey=$confirmationKey";
 
-                                //Attempt email send
-                                $subject = sprintf(__($guid, 'Request For Mentor Feedback via %1$s at %2$s', 'Free Learning'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationNameShort']);
-                                $body = __($guid, 'To whom it may concern,', 'Free Learning').'<br/><br/>';
-                                if ($roleCategory == 'Staff') {
-                                    $roleCategoryFull = 'member of staff';
-                                }
-                                else {
-                                    $roleCategoryFull = strtolower($roleCategory);
-                                }
-                                $roleCategoryFull = __($guid, $roleCategoryFull) ;
+                                $body = $container->get(View::class)->fetchFromTemplate('mentorSubmit.twig.html', [
+                                    'roleCategoryFull' => $roleCategory == 'Staff' ? __m('member of staff') : __(strtolower($roleCategory)),
+                                    'unitName' => $name,
+                                    'studentName' => $studentName,
+                                    'organisationNameShort' => $gibbon->session->get('organisationNameShort'),
+                                    'organisationAdministratorName' => $gibbon->session->get('organisationAdministratorName'),
+                                    'organisationAdministratorEmail' => $gibbon->session->get('organisationAdministratorEmail'),
+                                ]);
 
-                                $body .= sprintf(__($guid, 'The following %1$s at %2$s has requested your feedback on their %3$sFree Learning%4$s work (%5$s), which they have just submitted, and on which you previously agreed to mentor them.', 'Free Learning'), $roleCategoryFull, $_SESSION[$guid]['systemName'], "<a target='_blank' href='http://rossparker.org'>", '</a>', '<b>'.$name.'</b>');
-                                $body .= '<br/>';
-                                $body .= '<ul>';
-                                $body .= '<li>'.$student[0].'</li>';
-                                $body .= '</ul>';
-                                $body .= sprintf(__($guid, 'Please %1$sclick here%2$s to view and give feedback on the submitted work.', 'Free Learning'), "<a style='font-weight: bold; text-decoration: underline; color: #390' target='_blank' href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_mentor_approval.php&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey'>", '</a>');
-                                $body .= '<br/><br/>';
-                                $body .= sprintf(__($guid, 'Thank you very much for your time. Should you have any questions about this matter, please reply to this email, or contact %1$s on %2$s.', 'Free Learning'), $_SESSION[$guid]['organisationAdministratorName'], $_SESSION[$guid]['organisationAdministratorEmail']);
-                                $body .= '<br/><br/>';
-                                $body .= sprintf(__($guid, 'Email sent via %1$s at %2$s.', 'Free Learning'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']);
-                                $body .= '</p>';
-                                $bodyPlain = emailBodyConvert($body);
-
+                                // Attempt email send
                                 $mail = $container->get(Mailer::class);
-                                $mail->IsSMTP();
-                                $mail->SetFrom($_SESSION[$guid]['organisationEmail'], $_SESSION[$guid]['organisationName']);
-                                $mail->AddReplyTo($student[1], $student[0]);
-                                $mail->AddAddress($emailExternalMentor);
-                                $mail->CharSet = 'UTF-8';
-                                $mail->Encoding = 'base64';
-                                $mail->IsHTML(true);
-                                $mail->Subject = $subject;
-                                $mail->Body = $body;
-                                $mail->AltBody = $bodyPlain;
+                                $mail->AddReplyTo($studentEmail, $studentName);
+                                $mail->AddAddress($emailExternalMentor, $nameExternalMentor);
+                                $mail->setDefaultSender($subject);
+                                $mail->renderBody('mail/message.twig.html', [
+                                    'title'  => __m('Request For Mentor Feedback'),
+                                    'body'   => $body,
+                                    'button' => [
+                                        'url'  => $buttonURL,
+                                        'text' => __('View Evidence'),
+                                    ],
+                                ]);
 
-                                try {
-                                    $mail->Send();
-                                } catch (phpmailerException $e) {
-                                    print "there"; exit();
-                                }
-                            }
-                            else {
+                                $sent = $mail->Send();
+                                $partialFail &= !$sent;
+                            } else {
                                 $partialFail = true;
                             }
 

--- a/Free Learning/units_browse_details_completePendingProcess.php
+++ b/Free Learning/units_browse_details_completePendingProcess.php
@@ -25,7 +25,7 @@ require_once '../../gibbon.php';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
-$highestAction = getHighestGroupedAction($guid, $_GET['address'], $connection2);
+$highestAction = getHighestGroupedAction($guid, $_POST['address'], $connection2);
 
 //Get params
 $freeLearningUnitID = '';
@@ -66,7 +66,7 @@ if ($canManage) {
     }
 }
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=1&view='.$view;
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=1&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false) {
     //Fail 0

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -220,23 +220,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             ]));
 
             // ADD COMMENT
-            $commentBox = $form->getFactory()->createColumn()->addClass('flex flex-col');
-            $commentBox->addTextArea('addComment')
-                ->placeholder(__m('Leave a comment'))
-                ->setClass('flex w-full')
-                ->setRows(3);
-            $commentBox->addButton(__m('Add Comment'))
-                ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
-                ->setClass('button rounded-sm right');
+            if ($rowEnrol['enrolmentMethod'] != 'externalMentor') {
+                $commentBox = $form->getFactory()->createColumn()->addClass('flex flex-col');
+                $commentBox->addTextArea('addComment')
+                    ->placeholder(__m('Leave a comment'))
+                    ->setClass('flex w-full')
+                    ->setRows(3);
+                $commentBox->addButton(__m('Add Comment'))
+                    ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
+                    ->setClass('button rounded-sm right');
 
-            $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [
-                'discussion' => [[
-                    'surname' => $gibbon->session->get('surname'),
-                    'preferredName' => $gibbon->session->get('preferredName'),
-                    'image_240' => $gibbon->session->get('image_240'),
-                    'comment' => $commentBox->getOutput(),
-                ]]
-            ]));
+                $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [
+                    'discussion' => [[
+                        'surname' => $gibbon->session->get('surname'),
+                        'preferredName' => $gibbon->session->get('preferredName'),
+                        'image_240' => $gibbon->session->get('image_240'),
+                        'comment' => $commentBox->getOutput(),
+                    ]]
+                ]));
+            }
             
             echo $form->getOutput();
     
@@ -304,23 +306,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         ]));
 
         // ADD COMMENT
-        $commentBox = $form->getFactory()->createColumn();
-        $commentBox->addTextArea('addComment')
-            ->placeholder(__m('Leave a comment'))
-            ->setClass('flex w-full')
-            ->setRows(3);
-        $commentBox->addButton(__m('Add Comment'))
-            ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
-            ->setClass('button rounded-sm right');
+        if ($rowEnrol['enrolmentMethod'] != 'externalMentor') {
+            $commentBox = $form->getFactory()->createColumn();
+            $commentBox->addTextArea('addComment')
+                ->placeholder(__m('Leave a comment'))
+                ->setClass('flex w-full')
+                ->setRows(3);
+            $commentBox->addButton(__m('Add Comment'))
+                ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
+                ->setClass('button rounded-sm right');
 
-        $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [
-            'discussion' => [[
-                'surname' => $gibbon->session->get('surname'),
-                'preferredName' => $gibbon->session->get('preferredName'),
-                'image_240' => $gibbon->session->get('image_240'),
-                'comment' => $commentBox->getOutput(),
-            ]]
-        ]));
+            $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [
+                'discussion' => [[
+                    'surname' => $gibbon->session->get('surname'),
+                    'preferredName' => $gibbon->session->get('preferredName'),
+                    'image_240' => $gibbon->session->get('image_240'),
+                    'comment' => $commentBox->getOutput(),
+                ]]
+            ]));
+        }
 
         echo $form->getOutput();
 

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -344,7 +344,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         // Complete, show status and feedback from teacher.
 
         $logs = $unitStudentGateway->selectUnitStudentDiscussion($rowEnrol['freeLearningUnitStudentID'])->fetchAll();
-        $logContent .= $page->fetchFromTemplate('ui/discussion.twig.html', [
+        $logContent = $page->fetchFromTemplate('ui/discussion.twig.html', [
             'title' => __('Comments'),
             'discussion' => $logs
         ]);

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -226,7 +226,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 ->setClass('flex w-full')
                 ->setRows(3);
             $commentBox->addButton(__m('Add Comment'))
-                ->onClick('document.getElementById("enrolComment").submit()')
+                ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
                 ->setClass('button rounded-sm right');
 
             $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [
@@ -310,7 +310,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             ->setClass('flex w-full')
             ->setRows(3);
         $commentBox->addButton(__m('Add Comment'))
-            ->onClick('document.getElementById("enrolComment").submit()')
+            ->onClick('$(this).prop("disabled", true).wrap("<span class=\"submitted\"></span>");document.getElementById("enrolComment").submit()')
             ->setClass('button rounded-sm right');
 
         $form->addRow()->addClass('-mt-4')->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -200,7 +200,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 
             $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
             if ($collaborativeAssessment == 'Y' AND  !empty($rowEnrol['collaborationKey'])) {
-                $description .= Format::alert(__m('Collaborative Assessment is enabled: by submitting this work, you will be submitting on behalf of your collaborators as well as yourself.'), 'message');
+                $collaborators = $unitStudentGateway->selectUnitCollaboratorsByKey($rowEnrol['collaborationKey'])->fetchAll();
+                $collaborators = Format::nameListArray($collaborators, 'Student');
+
+                $description .= Format::alert(__m('Collaborative Assessment is enabled: by submitting this work, you will be submitting on behalf of your collaborators as well as yourself.') .'<br/><br/>'. __m('Your Group').': '. implode(', ', $collaborators), 'message');
             }
 
             if ($rowEnrol['status'] == 'Current') {

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -162,7 +162,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             $prerequisitesActive = prerequisitesRemoveInactive($connection2, $roleCategory == 'Student' ? $values['freeLearningUnitIDPrerequisiteList'] : '');
             $prerequisiteCount = !empty($prerequisitesActive) ? count(explode(',', $prerequisitesActive)) : 0;
 
-            $collaborators = $unitStudentGateway->selectUnitCollaborators($gibbonSchoolYearID, $gibbonPersonID, $roleCategory, $prerequisiteCount, $values)->fetchAll();
+            $collaborators = $unitStudentGateway->selectPotentialCollaborators($gibbonSchoolYearID, $gibbonPersonID, $roleCategory, $prerequisiteCount, $values)->fetchAll();
             $collaborators = Format::nameListArray($collaborators, 'Student', true);
 
             for ($i = 1; $i <= $extraSlots; ++$i) {

--- a/Free Learning/units_browse_details_enrolProcess.php
+++ b/Free Learning/units_browse_details_enrolProcess.php
@@ -25,7 +25,7 @@ require_once  './moduleFunctions.php';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
-$highestAction = getHighestGroupedAction($guid, $_GET['address'], $connection2);
+$highestAction = getHighestGroupedAction($guid, $_POST['address'], $connection2);
 
 //Get params
 $freeLearningUnitID = '';
@@ -67,7 +67,7 @@ if ($canManage) {
 }
 
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&sidebar=true&tab=1&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&view='.$view;
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&sidebar=true&tab=1&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false and !$canManage) {
     //Fail 0

--- a/Free Learning/units_mentor.php
+++ b/Free Learning/units_mentor.php
@@ -80,6 +80,14 @@ if (isset($_GET['confirmationKey'])) {
     $confirmationKey = $_GET['confirmationKey'];
 }
 
+$urlParams = compact('view', 'name', 'difficulty', 'gibbonDepartmentID', 'showInactive', 'freeLearningUnitID');
+$page->breadcrumbs
+    ->add(__m('Browse Units'), 'units_browse.php', $urlParams);
+
+if (isset($_GET['return'])) {
+    returnProcess($guid, $_GET['return'], null, array('success0' => __($guid, 'Your request was completed successfully. Thank you for your time.', 'Free Learning'), 'success1' => __($guid, 'Your request was completed successfully. Thank you for your time. The learners you are helping will be in touch in due course: in the meanwhile, no further action is required on your part.', 'Free Learning')));
+}
+
 if ($freeLearningUnitID != '' && isset($_SESSION[$guid]['gibbonPersonID'])) {
     //Check unit
     try {
@@ -98,18 +106,9 @@ if ($freeLearningUnitID != '' && isset($_SESSION[$guid]['gibbonPersonID'])) {
     } else {
         $row = $result->fetch();
 
-        $urlParams = compact('view', 'name', 'difficulty', 'gibbonDepartmentID', 'showInactive', 'freeLearningUnitID');
-
-        $page->breadcrumbs
-            ->add(__m('Browse Units'), 'units_browse.php', $urlParams);
-
         $urlParams["sidebar"] = "true";
         $page->breadcrumbs->add(__m('Unit Details'), 'units_browse_details.php', $urlParams)
             ->add(__m('Approval'));
-
-        if (isset($_GET['return'])) {
-            returnProcess($guid, $_GET['return'], null, array('success0' => __($guid, 'Your request was completed successfully. Thank you for your time.', 'Free Learning'), 'success1' => __($guid, 'Your request was completed successfully. Thank you for your time. The learners you are helping will be in touch in due course: in the meanwhile, no further action is required on your part.', 'Free Learning')));
-        }
 
         //Show choice for school mentor
         if ($mode == "internal" && $confirmationKey != '') {

--- a/Free Learning/units_mentor_approvalProcess.php
+++ b/Free Learning/units_mentor_approvalProcess.php
@@ -1,4 +1,7 @@
 <?php
+
+use Gibbon\Domain\System\DiscussionGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitStudentGateway;
 /*
 Gibbon, Flexible & Open School System
 Copyright (C) 2010, Ross Parker
@@ -64,62 +67,77 @@ if ($freeLearningUnitStudentID == '' or $freeLearningUnitID == '' or $confirmati
         $name = $row['unit'];
 
         //Get Inputs
-        $status = $_POST['status'];
-        $commentApproval = $_POST['commentApproval'];
-        $gibbonPersonIDStudent = $row['gibbonPersonIDStudent'];
+        $status = $_POST['status'] ?? '';
+        $gibbonPersonIDStudent = $row['gibbonPersonIDStudent'] ?? '';
+        $commentApproval = $_POST['commentApproval'] ?? '';
+        $commentApproval = trim(preg_replace('/^<p>|<\/p>$/i', '', $commentApproval));
 
         //Validation
         if ($commentApproval == '') {
             //Fail 3
             $URL .= '&return=error3';
             header("Location: {$URL}");
+        } elseif ($status != 'Complete - Approved' && $status != 'Evidence Not Yet Approved') {
+            $URL .= '&return=error3';
+            header("Location: {$URL}");
         } else {
-            if ($status == 'Complete - Approved') { //APPROVED!
-                //Write to database
-                try {
-                    $data = array('status' => $status, 'commentApproval' => $commentApproval, 'gibbonPersonIDApproval' => null, 'timestampCompleteApproved' => date('Y-m-d H:i:s'), 'freeLearningUnitStudentID' => $freeLearningUnitStudentID);
-                    $sql = 'UPDATE freeLearningUnitStudent SET status=:status, commentApproval=:commentApproval, gibbonPersonIDApproval=:gibbonPersonIDApproval, timestampCompleteApproved=:timestampCompleteApproved WHERE freeLearningUnitStudentID=:freeLearningUnitStudentID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    //Fail 2
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit;
-                }
+            // Post Discussion
+            $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
+            $discussionGateway = $container->get(DiscussionGateway::class);
+            $unitStudentGateway = $container->get(UnitStudentGateway::class);
+                
+            $data = [
+                'foreignTable'   => 'freeLearningUnitStudent',
+                'foreignTableID' => $freeLearningUnitStudentID,
+                'gibbonModuleID' => getModuleIDFromName($connection2, 'Free Learning'), 
+                'gibbonPersonID' => $gibbonPersonID,
+                'comment'        => $commentApproval,
+                'type'           => $status,
+                'tag'            => $status == 'Complete - Approved' ? 'success' : 'warning',
+            ];
 
+            if ($collaborativeAssessment == 'Y' AND !empty($row['collaborationKey'])) {
+                $collaborators = $unitStudentGateway->selectBy(['collaborationKey' => $row['collaborationKey']])->fetchAll();
+                foreach ($collaborators as $collaborator) {
+                    $data['foreignTableID'] = $collaborator['freeLearningUnitStudentID'];
+                    $discussionGateway->insert($data);
+                }
+            } else {
+                $discussionGateway->insert($data);
+            }
+
+            // Write to database
+            $unitStudentGateway = $container->get(UnitStudentGateway::class); 
+                        
+            $data = [
+                'status' => $status,
+                'commentApproval' => $commentApproval,
+                'gibbonPersonIDApproval' => null,
+                'timestampCompleteApproved' => date('Y-m-d H:i:s')
+            ];
+
+            if ($collaborativeAssessment == 'Y' AND !empty($row['collaborationKey'])) {
+                $updated = $unitStudentGateway->updateWhere(['collaborationKey' => $row['collaborationKey']], $data);
+            } else {
+                $updated = $unitStudentGateway->update($freeLearningUnitStudentID, $data);
+            }
+
+            if ($status == 'Complete - Approved') { //APPROVED!
                 //Attempt to notify the student and grant awards
                 $text = sprintf(__($guid, 'Your mentor has approved your request for unit completion (%1$s).', 'Free Learning'), $name);
                 $actionLink = "/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=&difficulty=&name=&showInactive=&sidebar=true&tab=1";
                 setNotification($connection2, $guid, $gibbonPersonIDStudent, $text, 'Free Learning', $actionLink);
                 grantBadges($connection2, $guid, $gibbonPersonIDStudent);
 
-
                 $URL .= '&return=success0';
                 header("Location: {$URL}");
             } elseif ($status == 'Evidence Not Yet Approved') { //NOT YET APPROVED
-                //Write to database
-                try {
-                    $data = array('status' => $status, 'commentApproval' => $commentApproval, 'commentApproval' => $commentApproval, 'gibbonPersonIDApproval' => $_SESSION[$guid]['gibbonPersonID'], 'timestampCompleteApproved' => date('Y-m-d H:i:s'), 'freeLearningUnitStudentID' => $freeLearningUnitStudentID);
-                    $sql = 'UPDATE freeLearningUnitStudent SET status=:status, commentApproval=:commentApproval, gibbonPersonIDApproval=:gibbonPersonIDApproval, timestampCompleteApproved=:timestampCompleteApproved WHERE freeLearningUnitStudentID=:freeLearningUnitStudentID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    //Fail 2
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit;
-                }
-
                 //Attempt to notify the student
                 $text = sprintf(__($guid, 'Your mentor has responded to your request for unit completion, but your evidence has not been approved (%1$s).', 'Free Learning'), $name);
                 $actionLink = "/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&sidebar=true&tab=1&view=$view";
                 setNotification($connection2, $guid, $gibbonPersonIDStudent, $text, 'Free Learning', $actionLink);
 
                 $URL .= '&return=success1';
-                header("Location: {$URL}");
-            } else {
-                $URL .= '&return=error3';
                 header("Location: {$URL}");
             }
         }

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.31';
+$moduleVersion = '5.10.00';

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.9.30';
+$moduleVersion = '5.9.31';


### PR DESCRIPTION
This is a big one 😅 

In this PR:

- Added the ability for students and mentors to comment on units.
- Enabled parents viewing their children's units on the map view.
- Fixed collaborative submissions for external mentorship.
- Updated external mentorship emails to use an email template.
- Ooified the Enrol tab and Mentorship forms.

Other fixes:
- Prerequisite check for collaborators now properly excludes students who have already completed the unit, rather than generating an error.
- Collaborators are listed in the student view to remind them of their group members.
- All comment sections show up before form submission/unit details, for consistency.
- Fixed ooification bug where exemplar fields were not saving correctly.

The most notable change is being able to comment on a unit without students submitting evidence or mentors submitting feedback. This enables users to make use of the discussion feature to ask questions or leave comments without changing the status of the unit. Comments send notifications to users much in the same way as submissions.

The comment box is visually distinct from the submission box to help clarify the uses for both forms:

![Screenshot_2020-09-18 DEMO - Gibbon - Free Learning](https://user-images.githubusercontent.com/897700/93546357-2f771c80-f995-11ea-8ac4-66d240f6606e.png)

The external mentor page has been ooified and mentor emails now look nicer by using email templates:

<img width="565" alt="Screenshot 2020-09-18 at 9 49 33 AM" src="https://user-images.githubusercontent.com/897700/93545989-6d277580-f994-11ea-8f11-343ccb5eb116.png">

