### PR TITLE
Replace sessions variables with 'get' and 'exists' methods

### DIFF
--- a/Free Learning/badges_manage.php
+++ b/Free Learning/badges_manage.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
         echo __($guid, 'Search');
         echo '</h2>';
         ?>
-        <form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
+        <form method="get" action="<?php echo $gibbon->session->get('absoluteURL') ?>/index.php">
             <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                 <tr>
                     <td>
@@ -67,10 +67,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                 </tr>
                 <tr>
                     <td colspan=2 class="right">
-                        <input type="hidden" name="q" value="/modules/<?php echo $_SESSION[$guid]['module'] ?>/badges_manage.php">
-                        <input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
+                        <input type="hidden" name="q" value="/modules/<?php echo $gibbon->session->get('module') ?>/badges_manage.php">
+                        <input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
                         <?php
-                        echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/badges_manage.php'>Clear Search</a> "; ?>
+                        echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.$gibbon->session->get('module')."/badges_manage.php'>Clear Search</a> "; ?>
                         <input type="submit" value="Submit">
                     </td>
                 </tr>
@@ -96,22 +96,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                     WHERE (badgesBadge.name LIKE :search1 OR badgesBadge.category LIKE :search2)
                     ORDER BY category, name';
             }
-            $sqlPage = $sql.' LIMIT '.$_SESSION[$guid]['pagination'].' OFFSET '.(($page - 1) * $_SESSION[$guid]['pagination']);
+            $sqlPage = $sql.' LIMIT '.$gibbon->session->get('pagination').' OFFSET '.(($page - 1) * $gibbon->session->get('pagination'));
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) { echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         echo "<div class='linkTop'>";
-        echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/badges_manage_add.php&search=$search'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
+        echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/badges_manage_add.php&search=$search'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/page_new.png'/></a>";
         echo '</div>';
 
         if ($result->rowCount() < 1) { echo "<div class='error'>";
             echo __($guid, 'There are no badges to display.', 'Free Learning');
             echo '</div>';
         } else {
-            if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-                printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'top', "search=$search");
+            if ($result->rowCount() > $gibbon->session->get('pagination')) {
+                printPagination($guid, $result->rowCount(), $page, $gibbon->session->get('pagination'), 'top', "search=$search");
             }
 
             echo "<table cellspacing='0' style='width: 100%'>";
@@ -154,9 +154,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                 echo "<tr class=$rowNum>";
                 echo '<td>';
                 if ($row['logo'] != '') {
-                    echo "<img class='user' style='max-width: 150px' src='".$_SESSION[$guid]['absoluteURL'].'/'.$row['logo']."'/>";
+                    echo "<img class='user' style='max-width: 150px' src='".$gibbon->session->get('absoluteURL').'/'.$row['logo']."'/>";
                 } else {
-                    echo "<img class='user' style='max-width: 150px' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_240_square.jpg'/>";
+                    echo "<img class='user' style='max-width: 150px' src='".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_240_square.jpg'/>";
                 }
                 echo '</td>';
                 echo '<td>';
@@ -175,9 +175,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                 echo '});';
                 echo '});';
                 echo '</script>';
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/badges_manage_edit.php&freeLearningBadgeID='.$row['freeLearningBadgeID']."&search=$search'><img title='Edit' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/badges_manage_edit.php&freeLearningBadgeID='.$row['freeLearningBadgeID']."&search=$search'><img title='Edit' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/config.png'/></a> ";
                 if ($row['description'] != '') {
-                    echo "<a class='show_hide-$count' onclick='false' href='#'><img style='padding-right: 5px' src='".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/page_down.png' title='Show Description' onclick='return false;' /></a>";
+                    echo "<a class='show_hide-$count' onclick='false' href='#'><img style='padding-right: 5px' src='".$gibbon->session->get('absoluteURL')."/themes/Default/img/page_down.png' title='Show Description' onclick='return false;' /></a>";
                 }
                 echo '</td>';
                 echo '</tr>';
@@ -191,8 +191,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
             }
             echo '</table>';
 
-            if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-                printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'bottom', "search=$search");
+            if ($result->rowCount() > $gibbon->session->get('pagination')) {
+                printPagination($guid, $result->rowCount(), $page, $gibbon->session->get('pagination'), 'bottom', "search=$search");
             }
         }
     }

--- a/Free Learning/badges_manage_add.php
+++ b/Free Learning/badges_manage_add.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
         $returns = array();
         $editLink = '';
         if (isset($_GET['editID'])) {
-            $editLink = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/badges_manage_edit.php&freeLearningBadgeID='.$_GET['editID'].'&search='.$_GET['search'];
+            $editLink = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/badges_manage_edit.php&freeLearningBadgeID='.$_GET['editID'].'&search='.$_GET['search'];
         }
         if (isset($_GET['return'])) {
             returnProcess($guid, $_GET['return'], $editLink, null);
@@ -50,12 +50,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
 
         if ($_GET['search'] != '') {
             echo "<div class='linkTop'>";
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/badges_manage.php&search='.$_GET['search']."'>".__($guid, 'Back to Search Results')."</a>";
+            echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/badges_manage.php&search='.$_GET['search']."'>".__($guid, 'Back to Search Results')."</a>";
             echo '</div>';
         }
 
         ?>
-        <form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/Free Learning/badges_manage_addProcess.php?search='.$_GET['search'] ?>" enctype="multipart/form-data">
+        <form method="post" action="<?php echo $gibbon->session->get('absoluteURL').'/modules/Free Learning/badges_manage_addProcess.php?search='.$_GET['search'] ?>" enctype="multipart/form-data">
             <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                 <tr>
                     <td>
@@ -229,7 +229,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                         <span style="font-size: 90%"><i><?php echo __($guid, '* denotes a required field'); ?></i></span>
                     </td>
                     <td class="right">
-                        <input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
+                        <input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
                         <input type="submit" value="Submit">
                     </td>
                 </tr>

--- a/Free Learning/badges_manage_addProcess.php
+++ b/Free Learning/badges_manage_addProcess.php
@@ -21,7 +21,7 @@ require_once '../../gibbon.php';
 
 require_once  './moduleFunctions.php';
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/badges_manage_add.php&search='.$_GET['search'];
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/badges_manage_add.php&search='.$_GET['search'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manage_add.php') == false) {
     //Fail 0

--- a/Free Learning/badges_manage_edit.php
+++ b/Free Learning/badges_manage_edit.php
@@ -73,11 +73,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
 
                 if ($_GET['search'] != '') {
                     echo "<div class='linkTop'>";
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/badges_manage.php&search='.$_GET['search']."'>".__($guid, 'Back to Search Results')."</a>";
+                    echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/badges_manage.php&search='.$_GET['search']."'>".__($guid, 'Back to Search Results')."</a>";
                     echo '</div>';
                 }
                 ?>
-                <form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL']."/modules/Free Learning/badges_manage_editProcess.php?freeLearningBadgeID=$freeLearningBadgeID&search=".$_GET['search'] ?>" enctype="multipart/form-data">
+                <form method="post" action="<?php echo $gibbon->session->get('absoluteURL')."/modules/Free Learning/badges_manage_editProcess.php?freeLearningBadgeID=$freeLearningBadgeID&search=".$_GET['search'] ?>" enctype="multipart/form-data">
                     <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                         <tr>
                             <td>
@@ -259,7 +259,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manag
                                 <span style="font-size: 90%"><i><?php echo __($guid, '* denotes a required field'); ?></i></span>
                             </td>
                             <td class="right">
-                                <input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
+                                <input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
                                 <input type="submit" value="Submit">
                             </td>
                         </tr>

--- a/Free Learning/badges_manage_editProcess.php
+++ b/Free Learning/badges_manage_editProcess.php
@@ -22,7 +22,7 @@ require_once '../../gibbon.php';
 require_once  './moduleFunctions.php';
 
 $freeLearningBadgeID = $_GET['freeLearningBadgeID'];
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/badges_manage_edit.php&freeLearningBadgeID=$freeLearningBadgeID&search=".$_GET['search'];
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/badges_manage_edit.php&freeLearningBadgeID=$freeLearningBadgeID&search=".$_GET['search'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_manage_edit.php') == false) {
     //Fail 0

--- a/Free Learning/badges_view.php
+++ b/Free Learning/badges_view.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_view.
                 FROM  freeLearningBadge
                     JOIN badgesBadge ON (freeLearningBadge.badgesBadgeID=badgesBadge.badgesBadgeID)
                 ORDER BY unitsCompleteTotal, unitsCompleteDepartmentCount, name';
-            $sqlPage = $sql.' LIMIT '.$_SESSION[$guid]['pagination'].' OFFSET '.(($page - 1) * $_SESSION[$guid]['pagination']);
+            $sqlPage = $sql.' LIMIT '.$gibbon->session->get('pagination').' OFFSET '.(($page - 1) * $gibbon->session->get('pagination'));
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) { echo "<div class='error'>".$e->getMessage().'</div>';
@@ -60,8 +60,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_view.
             echo __($guid, 'There are no badges to display.', 'Free Learning');
             echo '</div>';
         } else {
-            if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-                printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'top');
+            if ($result->rowCount() > $gibbon->session->get('pagination')) {
+                printPagination($guid, $result->rowCount(), $page, $gibbon->session->get('pagination'), 'top');
             }
 
             echo "<table cellspacing='0' style='width: 100%'>";
@@ -104,9 +104,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_view.
                 echo "<tr class=$rowNum>";
                 echo '<td>';
                 if ($row['logo'] != '') {
-                    echo "<img class='user' style='max-width: 150px' src='".$_SESSION[$guid]['absoluteURL'].'/'.$row['logo']."'/>";
+                    echo "<img class='user' style='max-width: 150px' src='".$gibbon->session->get('absoluteURL').'/'.$row['logo']."'/>";
                 } else {
-                    echo "<img class='user' style='max-width: 150px' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_240_square.jpg'/>";
+                    echo "<img class='user' style='max-width: 150px' src='".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_240_square.jpg'/>";
                 }
                 echo '</td>';
                 echo '<td>';
@@ -121,8 +121,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/badges_view.
             }
             echo '</table>';
 
-            if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-                printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'bottom');
+            if ($result->rowCount() > $gibbon->session->get('pagination')) {
+                printPagination($guid, $result->rowCount(), $page, $gibbon->session->get('pagination'), 'bottom');
             }
         }
     }

--- a/Free Learning/hook_parentalDashboard_unitHistory.php
+++ b/Free Learning/hook_parentalDashboard_unitHistory.php
@@ -29,8 +29,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
     $returnInt .= '</div>';
 } else {
     $returnInt .= "<div class='linkTop'>";
-    $returnInt .= sprintf(__($guid, '%1$sView Showcase of Student Work%2$s', 'Free Learning'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/showcase.php'>", '</a>')." | ";
-    $returnInt .= sprintf(__($guid, '%1$sBrowse Units%2$s', 'Free Learning'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_browse.php'>", '</a>');
+    $returnInt .= sprintf(__($guid, '%1$sView Showcase of Student Work%2$s', 'Free Learning'), "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/showcase.php'>", '</a>')." | ";
+    $returnInt .= sprintf(__($guid, '%1$sBrowse Units%2$s', 'Free Learning'), "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_browse.php'>", '</a>');
     $returnInt .= '</div>';
     $returnInt .= "<p style='margin-top: 20px'>";
     $returnInt .= __($guid, 'This table shows recent results and enrolment for Free Learning units studied by your child:', 'Free Learning');

--- a/Free Learning/hook_studentDashboard_unitHistory.php
+++ b/Free Learning/hook_studentDashboard_unitHistory.php
@@ -29,8 +29,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
     $returnInt .= '</div>';
 } else {
     $returnInt .= "<div class='linkTop'>";
-    $returnInt .= sprintf(__($guid, '%1$sView Showcase of Student Work%2$s', 'Free Learning'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/showcase.php'>", '</a>')." | ";
-    $returnInt .= sprintf(__($guid, '%1$sBrowse Units%2$s', 'Free Learning'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_browse.php'>", '</a>');
+    $returnInt .= sprintf(__($guid, '%1$sView Showcase of Student Work%2$s', 'Free Learning'), "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/showcase.php'>", '</a>')." | ";
+    $returnInt .= sprintf(__($guid, '%1$sBrowse Units%2$s', 'Free Learning'), "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_browse.php'>", '</a>');
     $returnInt .= '</div>';
     $returnInt .= "<p style='margin-top: 20px'>";
     $returnInt .= __($guid, 'This table shows your recent results and enrolment for Free Learning:', 'Free Learning');

--- a/Free Learning/moduleFunctions.php
+++ b/Free Learning/moduleFunctions.php
@@ -73,7 +73,7 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
     }
 
     //Do it!
-    if ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false) {
+    if ($publicUnits == 'Y' and !$gibbon->session->exists('username')) {
         $sql = "SELECT DISTINCT freeLearningUnit.*, NULL AS status FROM freeLearningUnit WHERE sharedPublic='Y' AND gibbonYearGroupIDMinimum IS NULL AND active='Y' $sqlWhere ORDER BY $difficultyOrder name";
     } else {
         if ($highestAction == 'Browse Units_all') {
@@ -85,9 +85,9 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
             }
         } elseif ($highestAction == 'Browse Units_prerequisites') {
             if ($roleCategory == 'Student') {
-                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
-                $data['gibbonPersonID2'] = $_SESSION[$guid]['gibbonPersonID'];
-                $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
+                $data['gibbonPersonID2'] = $gibbon->session->get('gibbonPersonID');
+                $data['gibbonSchoolYearID'] = $gibbon->session->get('gibbonSchoolYearID');
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status, gibbonYearGroup.sequenceNumber AS sn1, gibbonYearGroup2.sequenceNumber AS sn2
                 FROM freeLearningUnit
                 LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID2)
@@ -98,15 +98,15 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
                 ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Parent') {
-                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableParents='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Staff') {
-                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableStaff='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Other') {
-                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableOther='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
         }
@@ -130,7 +130,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
     $output = false;
 
     try {
-        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
         $sql = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name
             FROM
                 gibbonPerson
@@ -219,7 +219,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                 }
                 $output .= '</td>';
                 $output .= '<td>';
-                $output .= "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$row['freeLearningUnitID']."&sidebar=true'>".$row['unit'].'</a>';
+                $output .= "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$row['freeLearningUnitID']."&sidebar=true'>".$row['unit'].'</a>';
                 $output .= '</td>';
                 $output .= '<td>';
                     $output .= ucwords(preg_replace('/(?<=\\w)(?=[A-Z])/'," $1", $row["enrolmentMethod"])).'<br/>';
@@ -239,7 +239,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                     if ($row['evidenceType'] == 'Link') {
                         $output .= "<a target='_blank' href='".$row['evidenceLocation']."'>".__($guid, 'View').'</>';
                     } else {
-                        $output .= "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$row['evidenceLocation']."'>".__($guid, 'View').'</>';
+                        $output .= "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$row['evidenceLocation']."'>".__($guid, 'View').'</>';
                     }
                 }
                 $output .= '</td>';
@@ -254,7 +254,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                     $output .= '});';
                     $output .= '});';
                     $output .= '</script>';
-                    $output .= "<a title='".__($guid, 'Show Comment')."' class='show_hide-".$row['freeLearningUnitStudentID']."' onclick='false' href='#'><img style='padding-right: 5px' src='".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
+                    $output .= "<a title='".__($guid, 'Show Comment')."' class='show_hide-".$row['freeLearningUnitStudentID']."' onclick='false' href='#'><img style='padding-right: 5px' src='".$gibbon->session->get('absoluteURL')."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
                 }
                 $output .= '</td>';
                 $output .= '</tr>';
@@ -470,7 +470,7 @@ function getLearningAreas($connection2, $guid, $limit = false)
     $output = false;
     try {
         if ($limit == true) {
-            $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+            $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
             $sql = "SELECT * FROM gibbonDepartment JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE type='Learning Area' AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)')  ORDER BY name";
         } else {
             $data = array();
@@ -519,7 +519,7 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 				$( ".sortable" ).bind( "sortstart", function(event, ui) {
 					$("#blockInner<?php echo $i ?>").css("display","none") ;
 					$("#block<?php echo $i ?>").css("height","72px") ;
-					$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
+					$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
 					tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 					tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
 					$(".sortable").sortable( "refresh" ) ;
@@ -538,13 +538,13 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 					if ($("#blockInner<?php echo $i ?>").is(":visible")) {
 						$("#blockInner<?php echo $i ?>").css("display","none");
 						$("#block<?php echo $i ?>").css("height","72px")
-						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
+						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
 					} else {
 						$("#blockInner<?php echo $i ?>").slideDown("fast", $("#blockInner<?php echo $i ?>").css("display","table-row"));
 						$("#block<?php echo $i ?>").css("height","auto")
-						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/minus.png\'"?>)");
+						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/minus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceAddEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
@@ -575,7 +575,7 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 				<td style='text-align: right; width: 50%'>
 					<div style='margin-bottom: 5px'>
 						<?php
-                        echo "<img id='delete$i' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/> "; echo "<div title='".__($guid, 'Show/Hide Details')."' id='show$i' style='margin-right: 3px; margin-top: -1px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\"); background-repeat: no-repeat'></div></br>"; ?>
+                        echo "<img id='delete$i' title='".__($guid, 'Delete')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/garbage.png'/> "; echo "<div title='".__($guid, 'Show/Hide Details')."' id='show$i' style='margin-right: 3px; margin-top: -1px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\"); background-repeat: no-repeat'></div></br>"; ?>
 					</div>
 					<input type='hidden' name='freeLearningUnitBlockID<?php echo $i ?>' value='<?php echo $freeLearningUnitBlockID ?>'>
 					<input type='hidden' name='freeLearningUnitClassBlockID<?php echo $i ?>' value='<?php echo $freeLearningUnitClassBlockID ?>'>
@@ -626,7 +626,7 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 				$( "#<?php echo $type ?>" ).bind( "sortstart", function(event, ui) {
 					$("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","none");
 					$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","72px") ;
-					$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
+					$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
 					tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					$("#<?php echo $type ?>").sortable( "refreshPositions" ) ;
 				});
@@ -648,12 +648,12 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 					if ($("#<?php echo $type ?>BlockInner<?php echo $i ?>").is(":visible")) {
 						$("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","none");
 						$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","72px") ;
-						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
+						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					} else {
 						$("#<?php echo $type ?>BlockInner<?php echo $i ?>").slideDown("fast", $("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","table-row"));
 						$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","auto")
-						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/minus.png\'"?>)");
+						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/minus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceAddEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					}
@@ -686,7 +686,7 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 					<td style='text-align: right; width: 50%'>
 						<div style='margin-bottom: 25px'>
 							<?php
-                            echo "<img id='".$type."delete$i' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/> "; echo "<div id='".$type."show$i' title='".__($guid, 'Show/Hide Details')."' style='margin-right: 3px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\"); background-repeat: no-repeat'></div>"; ?>
+                            echo "<img id='".$type."delete$i' title='".__($guid, 'Delete')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/garbage.png'/> "; echo "<div id='".$type."show$i' title='".__($guid, 'Show/Hide Details')."' style='margin-right: 3px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\"); background-repeat: no-repeat'></div>"; ?>
 						</div>
 						<input type='hidden' name='id<?php echo $i ?>' value='<?php echo $id ?>'>
 					</td>
@@ -741,7 +741,7 @@ function displayBlockContent($guid, $connection2, $title, $type, $length, $conte
     if ($contents != '') {
         $return .= "<div style='margin-top:20px; padding: 25px 3px 10px 3px; width: 100%; text-align: justify; border-bottom: 1px solid #ddd'>".$contents.'</div>';
     }
-    if (isset($_SESSION[$guid]['username'])) {
+    if ($gibbon->session->exists('username')) {
         if ($roleCategory == 'Staff') {
             if ($teachersNotes != '') {
                 $return .= "<div style='margin-top:20px; background-color: #F6CECB; padding: 0px 3px 10px 3px; width: 98%; text-align: justify; border-bottom: 1px solid #ddd'><p style='margin-bottom: 0px'><b>".__($guid, "Teacher's Notes").':</b></p> '.$teachersNotes.'</div>';
@@ -801,7 +801,7 @@ function grantBadges($connection2, $guid, $gibbonPersonID) {
                 $hitsNeeded ++;
                 try {
                     //Count conditions
-                    $dataCount = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                    $dataCount = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                     $sqlCount = "SELECT freeLearningUnitStudentID FROM freeLearningUnitStudent WHERE gibbonPersonIDStudent=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND status='Complete - Approved'";
                     $resultCount = $connection2->prepare($sqlCount);
                     $resultCount->execute($dataCount);
@@ -946,7 +946,7 @@ function grantBadges($connection2, $guid, $gibbonPersonID) {
             //GRANT AWARD
             if ($hitsNeeded > 0 AND $hitsActually == $hitsNeeded) {
                 try {
-                    $dataGrant = array('badgesBadgeID' => $row['badgesBadgeID'], 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'date' => date('Y-m-d'), 'gibbonPersonID' => $gibbonPersonID, 'comment' => '', 'gibbonPersonIDCreator' => null);
+                    $dataGrant = array('badgesBadgeID' => $row['badgesBadgeID'], 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'date' => date('Y-m-d'), 'gibbonPersonID' => $gibbonPersonID, 'comment' => '', 'gibbonPersonIDCreator' => null);
                     $sqlGrant = 'INSERT INTO badgesBadgeStudent SET badgesBadgeID=:badgesBadgeID, gibbonSchoolYearID=:gibbonSchoolYearID, date=:date, gibbonPersonID=:gibbonPersonID, comment=:comment, gibbonPersonIDCreator=:gibbonPersonIDCreator';
                     $resultGrant = $connection2->prepare($sqlGrant);
                     $resultGrant->execute($dataGrant);

--- a/Free Learning/moduleFunctions.php
+++ b/Free Learning/moduleFunctions.php
@@ -73,7 +73,7 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
     }
 
     //Do it!
-    if ($publicUnits == 'Y' and !$gibbon->session->exists('username')) {
+    if ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false) {
         $sql = "SELECT DISTINCT freeLearningUnit.*, NULL AS status FROM freeLearningUnit WHERE sharedPublic='Y' AND gibbonYearGroupIDMinimum IS NULL AND active='Y' $sqlWhere ORDER BY $difficultyOrder name";
     } else {
         if ($highestAction == 'Browse Units_all') {
@@ -85,9 +85,9 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
             }
         } elseif ($highestAction == 'Browse Units_prerequisites') {
             if ($roleCategory == 'Student') {
-                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
-                $data['gibbonPersonID2'] = $gibbon->session->get('gibbonPersonID');
-                $data['gibbonSchoolYearID'] = $gibbon->session->get('gibbonSchoolYearID');
+                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['gibbonPersonID2'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status, gibbonYearGroup.sequenceNumber AS sn1, gibbonYearGroup2.sequenceNumber AS sn2
                 FROM freeLearningUnit
                 LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID2)
@@ -98,15 +98,15 @@ function getUnitList($connection2, $guid, $gibbonPersonID, $roleCategory, $highe
                 ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Parent') {
-                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
+                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableParents='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Staff') {
-                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
+                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableStaff='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
             else if ($roleCategory == 'Other') {
-                $data['gibbonPersonID'] = $gibbon->session->get('gibbonPersonID');
+                $data['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
                 $sql = "SELECT DISTINCT freeLearningUnit.*, freeLearningUnitStudent.status FROM freeLearningUnit LEFT JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID) WHERE active='Y' AND availableOther='Y' $sqlWhere ORDER BY $difficultyOrder name";
             }
         }
@@ -130,7 +130,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
     $output = false;
 
     try {
-        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
+        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
         $sql = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name
             FROM
                 gibbonPerson
@@ -219,7 +219,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                 }
                 $output .= '</td>';
                 $output .= '<td>';
-                $output .= "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$row['freeLearningUnitID']."&sidebar=true'>".$row['unit'].'</a>';
+                $output .= "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$row['freeLearningUnitID']."&sidebar=true'>".$row['unit'].'</a>';
                 $output .= '</td>';
                 $output .= '<td>';
                     $output .= ucwords(preg_replace('/(?<=\\w)(?=[A-Z])/'," $1", $row["enrolmentMethod"])).'<br/>';
@@ -239,7 +239,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                     if ($row['evidenceType'] == 'Link') {
                         $output .= "<a target='_blank' href='".$row['evidenceLocation']."'>".__($guid, 'View').'</>';
                     } else {
-                        $output .= "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$row['evidenceLocation']."'>".__($guid, 'View').'</>';
+                        $output .= "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$row['evidenceLocation']."'>".__($guid, 'View').'</>';
                     }
                 }
                 $output .= '</td>';
@@ -254,7 +254,7 @@ function getStudentHistory($connection2, $guid, $gibbonPersonID, $summary = fals
                     $output .= '});';
                     $output .= '});';
                     $output .= '</script>';
-                    $output .= "<a title='".__($guid, 'Show Comment')."' class='show_hide-".$row['freeLearningUnitStudentID']."' onclick='false' href='#'><img style='padding-right: 5px' src='".$gibbon->session->get('absoluteURL')."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
+                    $output .= "<a title='".__($guid, 'Show Comment')."' class='show_hide-".$row['freeLearningUnitStudentID']."' onclick='false' href='#'><img style='padding-right: 5px' src='".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
                 }
                 $output .= '</td>';
                 $output .= '</tr>';
@@ -470,7 +470,7 @@ function getLearningAreas($connection2, $guid, $limit = false)
     $output = false;
     try {
         if ($limit == true) {
-            $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
+            $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
             $sql = "SELECT * FROM gibbonDepartment JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE type='Learning Area' AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)')  ORDER BY name";
         } else {
             $data = array();
@@ -519,7 +519,7 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 				$( ".sortable" ).bind( "sortstart", function(event, ui) {
 					$("#blockInner<?php echo $i ?>").css("display","none") ;
 					$("#block<?php echo $i ?>").css("height","72px") ;
-					$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
+					$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
 					tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 					tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
 					$(".sortable").sortable( "refresh" ) ;
@@ -538,13 +538,13 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 					if ($("#blockInner<?php echo $i ?>").is(":visible")) {
 						$("#blockInner<?php echo $i ?>").css("display","none");
 						$("#block<?php echo $i ?>").css("height","72px")
-						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
+						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
 					} else {
 						$("#blockInner<?php echo $i ?>").slideDown("fast", $("#blockInner<?php echo $i ?>").css("display","table-row"));
 						$("#block<?php echo $i ?>").css("height","auto")
-						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/minus.png\'"?>)");
+						$('#show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/minus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceAddEditor', false, 'contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceRemoveEditor', false, 'teachersNotes<?php echo $i ?>') ;
@@ -575,7 +575,7 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
 				<td style='text-align: right; width: 50%'>
 					<div style='margin-bottom: 5px'>
 						<?php
-                        echo "<img id='delete$i' title='".__($guid, 'Delete')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/garbage.png'/> "; echo "<div title='".__($guid, 'Show/Hide Details')."' id='show$i' style='margin-right: 3px; margin-top: -1px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\"); background-repeat: no-repeat'></div></br>"; ?>
+                        echo "<img id='delete$i' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/> "; echo "<div title='".__($guid, 'Show/Hide Details')."' id='show$i' style='margin-right: 3px; margin-top: -1px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\"); background-repeat: no-repeat'></div></br>"; ?>
 					</div>
 					<input type='hidden' name='freeLearningUnitBlockID<?php echo $i ?>' value='<?php echo $freeLearningUnitBlockID ?>'>
 					<input type='hidden' name='freeLearningUnitClassBlockID<?php echo $i ?>' value='<?php echo $freeLearningUnitClassBlockID ?>'>
@@ -626,7 +626,7 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 				$( "#<?php echo $type ?>" ).bind( "sortstart", function(event, ui) {
 					$("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","none");
 					$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","72px") ;
-					$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
+					$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
 					tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					$("#<?php echo $type ?>").sortable( "refreshPositions" ) ;
 				});
@@ -648,12 +648,12 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 					if ($("#<?php echo $type ?>BlockInner<?php echo $i ?>").is(":visible")) {
 						$("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","none");
 						$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","72px") ;
-						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\'"?>)");
+						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					} else {
 						$("#<?php echo $type ?>BlockInner<?php echo $i ?>").slideDown("fast", $("#<?php echo $type ?>BlockInner<?php echo $i ?>").css("display","table-row"));
 						$("#<?php echo $type ?>Block<?php echo $i ?>").css("height","auto")
-						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/minus.png\'"?>)");
+						$('#<?php echo $type ?>show<?php echo $i ?>').css("background-image", "<?php echo "url(\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/minus.png\'"?>)");
 						tinyMCE.execCommand('mceRemoveEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 						tinyMCE.execCommand('mceAddEditor', false, '<?php echo $type ?>contents<?php echo $i ?>') ;
 					}
@@ -686,7 +686,7 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 					<td style='text-align: right; width: 50%'>
 						<div style='margin-bottom: 25px'>
 							<?php
-                            echo "<img id='".$type."delete$i' title='".__($guid, 'Delete')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/garbage.png'/> "; echo "<div id='".$type."show$i' title='".__($guid, 'Show/Hide Details')."' style='margin-right: 3px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/plus.png\"); background-repeat: no-repeat'></div>"; ?>
+                            echo "<img id='".$type."delete$i' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/> "; echo "<div id='".$type."show$i' title='".__($guid, 'Show/Hide Details')."' style='margin-right: 3px; margin-left: 3px; padding-right: 1px; float: right; width: 25px; height: 25px; background-image: url(\"".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/plus.png\"); background-repeat: no-repeat'></div>"; ?>
 						</div>
 						<input type='hidden' name='id<?php echo $i ?>' value='<?php echo $id ?>'>
 					</td>
@@ -741,7 +741,7 @@ function displayBlockContent($guid, $connection2, $title, $type, $length, $conte
     if ($contents != '') {
         $return .= "<div style='margin-top:20px; padding: 25px 3px 10px 3px; width: 100%; text-align: justify; border-bottom: 1px solid #ddd'>".$contents.'</div>';
     }
-    if ($gibbon->session->exists('username')) {
+    if (isset($_SESSION[$guid]['username'])) {
         if ($roleCategory == 'Staff') {
             if ($teachersNotes != '') {
                 $return .= "<div style='margin-top:20px; background-color: #F6CECB; padding: 0px 3px 10px 3px; width: 98%; text-align: justify; border-bottom: 1px solid #ddd'><p style='margin-bottom: 0px'><b>".__($guid, "Teacher's Notes").':</b></p> '.$teachersNotes.'</div>';
@@ -801,7 +801,7 @@ function grantBadges($connection2, $guid, $gibbonPersonID) {
                 $hitsNeeded ++;
                 try {
                     //Count conditions
-                    $dataCount = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
+                    $dataCount = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
                     $sqlCount = "SELECT freeLearningUnitStudentID FROM freeLearningUnitStudent WHERE gibbonPersonIDStudent=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND status='Complete - Approved'";
                     $resultCount = $connection2->prepare($sqlCount);
                     $resultCount->execute($dataCount);
@@ -946,7 +946,7 @@ function grantBadges($connection2, $guid, $gibbonPersonID) {
             //GRANT AWARD
             if ($hitsNeeded > 0 AND $hitsActually == $hitsNeeded) {
                 try {
-                    $dataGrant = array('badgesBadgeID' => $row['badgesBadgeID'], 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'date' => date('Y-m-d'), 'gibbonPersonID' => $gibbonPersonID, 'comment' => '', 'gibbonPersonIDCreator' => null);
+                    $dataGrant = array('badgesBadgeID' => $row['badgesBadgeID'], 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'date' => date('Y-m-d'), 'gibbonPersonID' => $gibbonPersonID, 'comment' => '', 'gibbonPersonIDCreator' => null);
                     $sqlGrant = 'INSERT INTO badgesBadgeStudent SET badgesBadgeID=:badgesBadgeID, gibbonSchoolYearID=:gibbonSchoolYearID, date=:date, gibbonPersonID=:gibbonPersonID, comment=:comment, gibbonPersonIDCreator=:gibbonPersonIDCreator';
                     $resultGrant = $connection2->prepare($sqlGrant);
                     $resultGrant->execute($dataGrant);

--- a/Free Learning/report_currentUnitByClass.php
+++ b/Free Learning/report_currentUnitByClass.php
@@ -34,16 +34,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_curre
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $sort = $_GET['sort'] ?? 'unit';
 
-    $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'] . '/index.php', 'get');
+    $form = Form::create('filter', $gibbon->session->get('absoluteURL') . '/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->setClass('noIntBorder fullWidth');
     $form->setTitle(__m('Choose Class'));
 
-    $form->addHiddenValue('q', '/modules/' . $_SESSION[$guid]['module'] . '/report_currentUnitByClass.php');
+    $form->addHiddenValue('q', '/modules/' . $gibbon->session->get('module') . '/report_currentUnitByClass.php');
 
     $row = $form->addRow();
         $row->addLabel('gibbonCourseClassID', __('Class'));
-        $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'])
+        $row->addSelectClass('gibbonCourseClassID', $gibbon->session->get('gibbonSchoolYearID'), $gibbon->session->get('gibbonPersonID'))
             ->required()
             ->selected($gibbonCourseClassID)
             ->placeholder();
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_curre
             }
 
             echo "<div class='linkTop'>";
-            echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/report.php?q=/modules/'.$_SESSION[$guid]['module']."/report_students_byRollGroup_print.php&gibbonCourseClassID=$gibbonCourseClassID'>".__($guid, 'Print')."<img style='margin-left: 5px' title='".__($guid, 'Print')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/print.png'/></a>";
+            echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/report.php?q=/modules/'.$gibbon->session->get('module')."/report_students_byRollGroup_print.php&gibbonCourseClassID=$gibbonCourseClassID'>".__($guid, 'Print')."<img style='margin-left: 5px' title='".__($guid, 'Print')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/print.png'/></a>";
             echo '</div>';
 
             //Check for custom field
@@ -153,7 +153,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_curre
                 echo $count;
                 echo '</td>';
                 echo '<td>';
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$row['gibbonPersonID']."'>".formatName('', $row['preferredName'], $row['surname'], 'Student', true).'</a><br/>';
+                echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$row['gibbonPersonID']."'>".formatName('', $row['preferredName'], $row['surname'], 'Student', true).'</a><br/>';
                 $fields = unserialize($row['fields']);
                 if (!empty($fields[$customField])) {
                     $value = $fields[$customField];
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_curre
                 }
                 echo '</td>';
                 echo '<td>';
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&tab=2&freeLearningUnitID='.$row['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='>".htmlPrep($row['unitName']).'</a>';
+                echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&tab=2&freeLearningUnitID='.$row['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='>".htmlPrep($row['unitName']).'</a>';
                 echo "<br/><span style='font-size: 85%; font-style: italic'>".$row['status'].'</span>';
                 echo '</td>';
                 echo '<td>';

--- a/Free Learning/report_learningActivity.php
+++ b/Free Learning/report_learningActivity.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include "./modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php" ;
+include "./modules/" . $gibbon->session->get('module') . "/moduleFunctions.php" ;
 
 if (isActionAccessible($guid, $connection2, "/modules/Free Learning/report_learningActivity.php")==FALSE) {
     //Acess denied
@@ -39,7 +39,7 @@ else {
 
     ?>
 
-    <form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
+    <form method="get" action="<?php echo $gibbon->session->get('absoluteURL') ?>/index.php">
         <table class='smallIntBorder' cellspacing='0' style="width: 100%">
             <tr>
                 <td style='width: 275px'>
@@ -64,7 +64,7 @@ else {
             </tr>
             <tr>
                 <td colspan=2 class="right">
-                    <input type="hidden" name="q" value="/modules/<?php echo $_SESSION[$guid]['module'] ?>/report_learningActivity.php">
+                    <input type="hidden" name="q" value="/modules/<?php echo $gibbon->session->get('module') ?>/report_learningActivity.php">
                     <input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
                 </td>
             </tr>
@@ -119,7 +119,7 @@ else {
             echo '</table>';
 
             //PLOT DATA
-            echo '<script type="text/javascript" src="'.$_SESSION[$guid]['absoluteURL'].'/lib/Chart.js/Chart.min.js"></script>';
+            echo '<script type="text/javascript" src="'.$gibbon->session->get('absoluteURL').'/lib/Chart.js/Chart.min.js"></script>';
             echo "<p style='margin-top: 20px; margin-bottom: 5px'><b>".__($guid, 'Data').'</b></p>';
             echo '<div style="width:100%">';
             echo '<div>';

--- a/Free Learning/report_outcomes_byStudent.php
+++ b/Free Learning/report_outcomes_byStudent.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
     $gibbonPersonID = $_GET['gibbonPersonID'] ?? null;
     ?>
 
-    <form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
+    <form method="get" action="<?php echo $gibbon->session->get('absoluteURL') ?>/index.php">
         <table class='smallIntBorder' cellspacing='0' style="width: 100%">
             <tr>
                 <td style='width: 275px'>
@@ -47,7 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         <optgroup label='--<?php echo __($guid, 'Students by Roll Group') ?>--'>
                             <?php
                             try {
-                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
                                         $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
                                         FROM freeLearningUnitStudent
                                         JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID)
@@ -76,7 +76,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         <optgroup label='--<?php echo __($guid, 'Students by Name') ?>--'>
                             <?php
                             try {
-                                $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
                                         $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
                                         FROM freeLearningUnitStudent
                                         JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID) 
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
             </tr>
             <tr>
                 <td colspan=2 class="right">
-                    <input type="hidden" name="q" value="/modules/<?php echo $_SESSION[$guid]['module'] ?>/report_outcomes_byStudent.php">
+                    <input type="hidden" name="q" value="/modules/<?php echo $gibbon->session->get('module') ?>/report_outcomes_byStudent.php">
                     <input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
                 </td>
             </tr>
@@ -225,11 +225,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                     $output .= '</td>';
                     $output .= '<td>';
                     if (isset($outcomesMet[$rowOutcomes['gibbonOutcomeID']][0]) == false) {
-                        $output .= "<img title='".__($guid, 'Outcome not met', 'Free Learning')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconCross.png'/> ";
+                        $output .= "<img title='".__($guid, 'Outcome not met', 'Free Learning')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/iconCross.png'/> ";
                         $outcomesNotMet[$outcomesNotMetCount] = $rowOutcomes['gibbonOutcomeID'];
                         ++$outcomesNotMetCount;
                     } else {
-                        $output .= "<img title='".__($guid, 'Outcome met in units:', 'Free Learning').' '.htmlPrep($outcomesMet[$rowOutcomes['gibbonOutcomeID']][1])."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconTick.png'/> x".$outcomesMet[$rowOutcomes['gibbonOutcomeID']][0];
+                        $output .= "<img title='".__($guid, 'Outcome met in units:', 'Free Learning').' '.htmlPrep($outcomesMet[$rowOutcomes['gibbonOutcomeID']][1])."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/iconTick.png'/> x".$outcomesMet[$rowOutcomes['gibbonOutcomeID']][0];
                     }
                     $output .= '</td>';
                     $output .= '</tr>';
@@ -250,7 +250,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                 try {
                     $dataRecommend['gibbonPersonID'] = $gibbonPersonID;
                     $dataRecommend['gibbonPersonID2'] = $gibbonPersonID;
-                    $dataRecommend['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                    $dataRecommend['gibbonSchoolYearID'] = $gibbon->session->get('gibbonSchoolYearID');
                     $sqlRecommend = "SELECT DISTINCT freeLearningUnitStudent.status, freeLearningUnit.freeLearningUnitID, freeLearningUnit.*, gibbonYearGroup.sequenceNumber AS sn1, gibbonYearGroup2.sequenceNumber AS sn2
                         FROM freeLearningUnit
                         JOIN freeLearningUnitOutcome ON (freeLearningUnitOutcome.freeLearningUnitID=freeLearningUnit.freeLearningUnitID)
@@ -320,7 +320,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         echo $rowRecommend['status'];
                         echo "<div style='font-weight: bold; margin-top: 5px; margin-bottom: -6px ;'>".$rowRecommend['name'].'</div><br/>';
                         if ($rowRecommend['logo'] == null) {
-                            echo "<img style='margin-bottom: 10px; height: 125px; width: 125px' class='user' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_125.jpg'/><br/>";
+                            echo "<img style='margin-bottom: 10px; height: 125px; width: 125px' class='user' src='".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_125.jpg'/><br/>";
                         } else {
                             echo "<img style='margin-bottom: 10px; height: 125px; width: 125px' class='user' src='".$rowRecommend['logo']."'/><br/>";
                         }
@@ -393,7 +393,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_outco
                         }
                         echo '</td>';
                         echo '<td>';
-                        echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/units_browse_details.php&sidebar=true&freeLearningUnitID='.$rowRecommend['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='><img title='".__($guid, 'View')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/plus.png'/></a> ";
+                        echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.$gibbon->session->get('module').'/units_browse_details.php&sidebar=true&freeLearningUnitID='.$rowRecommend['freeLearningUnitID']."&gibbonDepartmentID=&difficulty=&name='><img title='".__($guid, 'View')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/plus.png'/></a> ";
                         echo '</td>';
                         echo '</tr>';
                     }

--- a/Free Learning/report_unitHistory_byStudent.php
+++ b/Free Learning/report_unitHistory_byStudent.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
         $gibbonPersonID = $_GET['gibbonPersonID'] ?? null;
         ?>
 
-        <form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
+        <form method="get" action="<?php echo $gibbon->session->get('absoluteURL')?>/index.php">
             <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                 <tr>
                     <td style='width: 275px'>
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <option></option>
                                 <?php
                                 try {
-                                    $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'today' => date('Y-m-d'));
+                                    $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'today' => date('Y-m-d'));
                                     $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonStudentEnrolmentID, surname, preferredName, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.nameShort AS rollGroup FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonFamilyChild ON (gibbonPerson.gibbonPersonID=gibbonFamilyChild.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID AND childDataAccess='Y') WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPerson.status='Full' AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today) ORDER BY surname, preferredName";
                                     $resultSelect = $connection2->prepare($sqlSelect);
                                     $resultSelect->execute($dataSelect);
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <optgroup label='--<?php echo __($guid, 'Students by Roll Group', 'Free Learning') ?>--'>
                                     <?php
                                     try {
-                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
                                         $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
                                         FROM freeLearningUnitStudent
                                         JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID)
@@ -108,7 +108,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                                 <optgroup label='--<?php echo __($guid, 'All Users by Name', 'Free Learning') ?>--'>
                                     <?php
                                     try {
-                                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d'));
+                                        $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
                                         $sqlSelect = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname, gibbonRollGroup.name AS name 
                                         FROM freeLearningUnitStudent
                                         JOIN gibbonPerson ON (freeLearningUnitStudent.gibbonPersonIDStudent=gibbonPerson.gibbonPersonID) 
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
                 </tr>
                 <tr>
                     <td colspan=2 class="right">
-                        <input type="hidden" name="q" value="/modules/<?php echo $_SESSION[$guid]['module'] ?>/report_unitHistory_byStudent.php">
+                        <input type="hidden" name="q" value="/modules/<?php echo $gibbon->session->get('module') ?>/report_unitHistory_byStudent.php">
                         <input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
                     </td>
                 </tr>
@@ -160,7 +160,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
             //Check access for parents
             if ($highestAction == 'Unit History By Student_myChildren') {
                 try {
-                    $dataChild = array('gibbonPersonID' => $gibbonPersonID, 'gibbonPersonID2' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                    $dataChild = array('gibbonPersonID' => $gibbonPersonID, 'gibbonPersonID2' => $gibbon->session->get('gibbonPersonID'), 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                     $sqlChild = "SELECT gibbonPerson.gibbonPersonID, surname, preferredName FROM gibbonFamilyChild JOIN gibbonPerson ON (gibbonFamilyChild.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID) WHERE gibbonFamilyAdult.childDataAccess='Y' AND gibbonPerson.gibbonPersonID=:gibbonPersonID AND gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID2 AND gibbonPerson.status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY surname, preferredName ";
                     $resultChild = $connection2->prepare($sqlChild);
                     $resultChild->execute($dataChild);

--- a/Free Learning/report_unitHistory_my.php
+++ b/Free Learning/report_unitHistory_my.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/report_unitH
         $page->breadcrumbs
              ->add(__m('Unit History by Student'));
 
-        $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+        $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 
         //Check access for parents
         echo getStudentHistory($connection2, $guid, $gibbonPersonID);

--- a/Free Learning/report_workPendingApproval.php
+++ b/Free Learning/report_workPendingApproval.php
@@ -51,11 +51,11 @@ else {
     $search = $_GET['search'] ?? '';
 
     if ($highestAction == 'Work Pending Approval_all') {
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form = Form::create('search', $gibbon->session->get('absoluteURL').'/index.php', 'get');
         $form->setTitle(__('Filter'));
         $form->setClass('noIntBorder fullWidth');
 
-        $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/report_workPendingApproval.php');
+        $form->addHiddenValue('q', '/modules/'.$gibbon->session->get('module').'/report_workPendingApproval.php');
 
         $row = $form->addRow();
             $row->addLabel('allMentors', __('All Mentors'))->description(__('Include evidence pending for all mentors.'));
@@ -180,7 +180,7 @@ else {
                 if (in_array($student['gibbonCourseClassID'], $myClasses)) {
                     $editEnrolment = true;
                 }
-            } elseif ($student['enrolmentMethod'] == 'schoolMentor' && $student['gibbonPersonIDSchoolMentor'] == $_SESSION[$guid]['gibbonPersonID']) {
+            } elseif ($student['enrolmentMethod'] == 'schoolMentor' && $student['gibbonPersonIDSchoolMentor'] == $gibbon->session->get('gibbonPersonID')) {
                 // Is mentor of this student?
                 $editEnrolment = true;
             }

--- a/Free Learning/showcase.php
+++ b/Free Learning/showcase.php
@@ -24,7 +24,7 @@ $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
 $canEdit = isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details_approval.php');
 
-if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.php') == true or ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false))) {
+if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.php') == true or ($publicUnits == 'Y' and !$gibbon->session->exists('username')))) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
@@ -46,14 +46,14 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.p
         $resultWork->execute($dataWork);
     } catch (PDOException $e) { echo "<div class='error'>".$e->getMessage().'</div>';
     }
-    $sqlPage = $sqlWork.' LIMIT '.$_SESSION[$guid]['pagination'].' OFFSET '.(($page - 1) * $_SESSION[$guid]['pagination']);
+    $sqlPage = $sqlWork.' LIMIT '.$gibbon->session->get('pagination').' OFFSET '.(($page - 1) * $gibbon->session->get('pagination'));
 
     if ($resultWork->rowCount() < 1) { echo "<div class='error'>";
         echo __($guid, 'There are no records to display.');
         echo '</div>';
     } else {
-        if ($resultWork->rowCount() > $_SESSION[$guid]['pagination']) {
-            printPagination($guid, $resultWork->rowCount(), $page, $_SESSION[$guid]['pagination'], 'top', '');
+        if ($resultWork->rowCount() > $gibbon->session->get('pagination')) {
+            printPagination($guid, $resultWork->rowCount(), $page, $gibbon->session->get('pagination'), 'top', '');
         }
 
         while ($rowWork = $resultWork->fetch()) {
@@ -85,7 +85,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.p
             echo '</p>';
             if ($canEdit) {
                 echo "<div class='linkTop'>";
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details_approval.php&freeLearningUnitID='.$rowWork['freeLearningUnitID'].'&freeLearningUnitStudentID='.$rowWork['freeLearningUnitStudentID']."&sidebar=true'>".__($guid, 'Edit')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a>";
+                echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details_approval.php&freeLearningUnitID='.$rowWork['freeLearningUnitID'].'&freeLearningUnitStudentID='.$rowWork['freeLearningUnitStudentID']."&sidebar=true'>".__($guid, 'Edit')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Edit')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/config.png'/></a>";
                 echo '</div>';
             }
             echo "<table style='width: 100%'>";
@@ -101,7 +101,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.p
                     echo "<img style='height: 150px; width: 150px; opacity: 1.0' class='user' src='".$rowWork['logo']."'/><br/>";
                 }
                 else {
-                    echo "<img style='height: 150px; width: 150px; opacity: 1.0' class='user' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_240_square.jpg'/><br/>";
+                    echo "<img style='height: 150px; width: 150px; opacity: 1.0' class='user' src='".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_240_square.jpg'/><br/>";
                 }
             }
             echo '</td>';
@@ -113,15 +113,15 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.p
                 if (strcasecmp($extension, '.gif') == 0 or strcasecmp($extension, '.jpg') == 0 or strcasecmp($extension, '.jpeg') == 0 or strcasecmp($extension, '.png') == 0) { //Its an image
                     echo "<p>";
                     if ($rowWork['evidenceType'] == 'File') { //It's a file
-                        echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'/></a>";
+                        echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'/></a>";
                     } else { //It's a link
-                        echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$rowWork['evidenceLocation']."'/></a>";
+                        echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$rowWork['evidenceLocation']."'/></a>";
                     }
                     echo '</p>';
                 } else { //Not an image
                     echo '<p class=\'button\'>';
                     if ($rowWork['evidenceType'] == 'File') { //It's a file
-                        echo "<a class='button' target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
+                        echo "<a class='button' target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
                     } else { //It's a link
                         echo "<a class='button' target='_blank' href='".$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
                     }
@@ -153,8 +153,8 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/showcase.p
             echo '</tr>';
             echo '</table>';
         }
-        if ($resultWork->rowCount() > $_SESSION[$guid]['pagination']) {
-            printPagination($guid, $resultWork->rowCount(), $page, $_SESSION[$guid]['pagination'], 'bottom', '');
+        if ($resultWork->rowCount() > $gibbon->session->get('pagination')) {
+            printPagination($guid, $resultWork->rowCount(), $page, $gibbon->session->get('pagination'), 'bottom', '');
         }
     }
 }

--- a/Free Learning/units_browse.php
+++ b/Free Learning/units_browse.php
@@ -31,17 +31,17 @@ require_once __DIR__ . '/moduleFunctions.php';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
-if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse.php') == true or ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false))) {
+if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse.php') == true or ($publicUnits == 'Y' and !$gibbon->session->exists('username')))) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Get action with highest precendence
-    if ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false) {
+    if ($publicUnits == 'Y' and !$gibbon->session->exists('username')) {
         $highestAction = 'Browse Units_all';
         $roleCategory = null ;
     } else {
         $highestAction = getHighestGroupedAction($guid, $_GET['q'], $connection2);
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
     }
     if ($highestAction == false) {
         $page->addError(__('The highest grouped action cannot be determined.'));
@@ -126,10 +126,10 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __m('View As'));
-                $row->addSelectUsers('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], ['includeStudents' => true])->selected($gibbonPersonID);
+                $row->addSelectUsers('gibbonPersonID', $gibbon->session->get('gibbonSchoolYearID'), ['includeStudents' => true])->selected($gibbonPersonID);
         } elseif ($roleCategory == 'Parent') {
             // Allow parents to view the map for their children
-            $children = $container->get(StudentGateway::class)->selectActiveStudentsByFamilyAdult($_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'])->fetchAll();
+            $children = $container->get(StudentGateway::class)->selectActiveStudentsByFamilyAdult($gibbon->session->get('gibbonSchoolYearID'), $gibbon->session->get('gibbonPersonID'))->fetchAll();
             $children = Format::nameListArray($children, 'Student', false, true);
 
             if (empty($children[$gibbonPersonID])) {
@@ -138,7 +138,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __m('View As'));
-                $row->addSelectPerson('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], ['includeStudents' => true])
+                $row->addSelectPerson('gibbonPersonID', $gibbon->session->get('gibbonSchoolYearID'), ['includeStudents' => true])
                     ->fromArray($children)
                     ->selected($gibbonPersonID);
         }
@@ -353,8 +353,8 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                 echo '<p>';
                 echo __($guid, 'The map below shows all units selected by the filters above. Lines between units represent prerequisites. Units without prerequisites, which make good starting units, are highlighted by a blue border.', 'Free Learning');
                 echo '</p>'; ?>
-                <script type="text/javascript" src="<?php echo $_SESSION[$guid]['absoluteURL'] ?>/lib/vis/dist/vis.js"></script>
-                <link href="<?php echo $_SESSION[$guid]['absoluteURL'] ?>/lib/vis/dist/vis.css" rel="stylesheet" type="text/css" />
+                <script type="text/javascript" src="<?php echo $gibbon->session->get('absoluteURL') ?>/lib/vis/dist/vis.js"></script>
+                <link href="<?php echo $gibbon->session->get('absoluteURL') ?>/lib/vis/dist/vis.css" rel="stylesheet" type="text/css" />
 
                 <div id="map" class="w-full border rounded shadow-inner mb-4" style="height: 800px;"></div>
 
@@ -371,7 +371,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                         if ($unit['logo'] != '') {
                             $image = $unit['logo'];
                         } else {
-                            $image = $_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/anonymous_240_square.jpg';
+                            $image = $gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName').'/img/anonymous_240_square.jpg';
                         }
                     } else {
                         $image = 'undefined';
@@ -509,7 +509,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     network.on( 'click', function(properties) {
                         var nodeNo = properties.nodes ;
                         if (nodeNo != '') {
-                            window.location = '<?php echo $_SESSION[$guid]['absoluteURL'] ?>/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&freeLearningUnitID=' + ids[nodeNo] + '&gibbonDepartmentID=<?php echo $gibbonDepartmentID ?>&difficulty=<?php echo $difficulty ?>&showInactive=<?php echo $showInactive; ?>&name=<?php echo $name ?>&view=<?php echo $view ?>';
+                            window.location = '<?php echo $gibbon->session->get('absoluteURL') ?>/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&freeLearningUnitID=' + ids[nodeNo] + '&gibbonDepartmentID=<?php echo $gibbonDepartmentID ?>&difficulty=<?php echo $difficulty ?>&showInactive=<?php echo $showInactive; ?>&name=<?php echo $name ?>&view=<?php echo $view ?>';
                         }
                     });
                 </script>

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -32,18 +32,18 @@ $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 $canManage = isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php');
 $browseAll = isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse.php', 'Browse Units_all');
 
-if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse.php') == true or ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false))) {
+if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse.php') == true or ($publicUnits == 'Y' and !$gibbon->session->exists('username')))) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Get action with highest precendence
-    if ($publicUnits == 'Y' and isset($_SESSION[$guid]['username']) == false) {
+    if ($publicUnits == 'Y' and !$gibbon->session->exists('username')) {
         $highestAction = 'Browse Units_all';
         $highestActionManage = null;
         $roleCategory = null ;
     } else {
         $highestAction = getHighestGroupedAction($guid, $_GET['q'], $connection2);
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
     }
     if ($highestAction == false) {
         $page->addError(__('The highest grouped action cannot be determined.'));
@@ -64,8 +64,8 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
         }
 
         $gibbonPersonID = ($canManage)
-            ? ($_GET['gibbonPersonID'] ?? $_SESSION[$guid]['gibbonPersonID'] ?? null)
-            : $_SESSION[$guid]['gibbonPersonID'] ?? null;
+            ? ($_GET['gibbonPersonID'] ?? $gibbon->session->get('gibbonPersonID') ?? null)
+            : $gibbon->session->get('gibbonPersonID') ?? null;
 
         $urlParams = compact('showInactive', 'gibbonDepartmentID', 'difficulty', 'name', 'view', 'gibbonPersonID', 'freeLearningUnitID');
 
@@ -109,7 +109,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                 $values = $result->fetch();
                 if ($gibbonDepartmentID != '' or $difficulty != '' or $name != '') {
                     echo "<div class='linkTop'>";
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_browse.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view'>".__($guid, 'Back to Search Results', 'Free Learning').'</a>';
+                    echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_browse.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view'>".__($guid, 'Back to Search Results', 'Free Learning').'</a>';
                     echo '</div>';
                 }
 
@@ -137,13 +137,13 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     if ($canManage || $browseAll) {
                         echo "<div class='linkTop'>";
                         if ($canManage) {
-                            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_manage_edit.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view'>".__($guid, 'Edit')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a>";
+                            echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_manage_edit.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view'>".__($guid, 'Edit')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Edit')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/config.png'/></a>";
                         }
                         if ($canManage & $browseAll) {
                             echo " | ";
                         }
                         if ($browseAll) {
-                            echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL']."/modules/Free Learning/units_browse_details_export.php?freeLearningUnitID=$freeLearningUnitID'>".__($guid, 'Export')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Export')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/download.png'/></a>";
+                            echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_browse_details_export.php?freeLearningUnitID=$freeLearningUnitID'>".__($guid, 'Export')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Export')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/download.png'/></a>";
                         }
                         echo '</div>';
                     }
@@ -194,7 +194,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                     echo '</td>';
                     echo "<td style='width: 135%!important; vertical-align: top; text-align: right' rowspan=4>";
                     if ($values['logo'] == null) {
-                        echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_125.jpg'/><br/>";
+                        echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_125.jpg'/><br/>";
                     } else {
                         echo "<img style='margin: 5px; height: 125px; width: 125px' class='user' src='".$values['logo']."'/><br/>";
                     }
@@ -511,7 +511,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                         if (in_array($student['gibbonCourseClassID'], $myClasses)) {
                                             $editEnrolment = true;
                                         }
-                                    } elseif ($student['enrolmentMethod'] == 'schoolMentor' && $student['gibbonPersonIDSchoolMentor'] == $_SESSION[$guid]['gibbonPersonID']) {
+                                    } elseif ($student['enrolmentMethod'] == 'schoolMentor' && $student['gibbonPersonIDSchoolMentor'] == $gibbon->session->get('gibbonPersonID')) {
                                         // Is mentor of this student?
                                         $editEnrolment = true;
                                     }
@@ -566,7 +566,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                         foreach ($blocks as $block) {
                             echo $templateView->fetchFromTemplate('unitBlock.twig.html', $block + [
                                 'roleCategory' => $roleCategory,
-                                'gibbonPersonID' => $_SESSION[$guid]['username'] ?? '',
+                                'gibbonPersonID' => $gibbon->session->get('username') ?? '',
                                 'blockCount' => $blockCount
                             ]);
                             $resourceContents .= $block['contents'];
@@ -755,7 +755,7 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                             echo '});';
                             echo '</script>';
                             if ($rowBlocks['content'] != '') {
-                                echo "<a title='".__($guid, 'View Description', 'Free Learning')."' class='show_hide-$count' onclick='false' href='#'><img style='padding-left: 0px' src='".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
+                                echo "<a title='".__($guid, 'View Description', 'Free Learning')."' class='show_hide-$count' onclick='false' href='#'><img style='padding-left: 0px' src='".$gibbon->session->get('absoluteURL')."/themes/Default/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
                             }
                             echo '</td>';
                             echo '</tr>';
@@ -820,15 +820,15 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                                 if (strcasecmp($extension, '.gif') == 0 or strcasecmp($extension, '.jpg') == 0 or strcasecmp($extension, '.jpeg') == 0 or strcasecmp($extension, '.png') == 0) { //Its an image
                                     echo "<p>";
                                     if ($rowWork['evidenceType'] == 'File') { //It's a file
-                                        echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'/></a>";
+                                        echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'/></a>";
                                     } else { //It's a link
-                                        echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$rowWork['evidenceLocation']."'/></a>";
+                                        echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'><img class='user' style='max-width: 550px' src='".$rowWork['evidenceLocation']."'/></a>";
                                     }
                                     echo '</p>';
                                 } else { //Not an image
                                     echo '<p class=\'button\'>';
                                     if ($rowWork['evidenceType'] == 'File') { //It's a file
-                                        echo "<a class='button'target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
+                                        echo "<a class='button'target='_blank' href='".$gibbon->session->get('absoluteURL').'/'.$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
                                     } else { //It's a link
                                         echo "<a class='button' target='_blank' href='".$rowWork['evidenceLocation']."'>".__($guid, 'Click to View Work', 'Free Learning').'</a>';
                                     }

--- a/Free Learning/units_browse_details_approval.php
+++ b/Free Learning/units_browse_details_approval.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         return;
     }
 
-    $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+    $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
     $canManage = isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') && $highestAction == 'Browse Units_all';
 
     // Get params
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     $freeLearningUnitID = $_GET['freeLearningUnitID'] ?? '';
     $gibbonPersonID = $canManage && !empty($_GET['gibbonPersonID'])
         ? $_GET['gibbonPersonID']
-        : $_SESSION[$guid]['gibbonPersonID'];
+        : $gibbon->session->get('gibbonPersonID');
 
     $urlParams = [
         'freeLearningUnitStudentID' => $freeLearningUnitStudentID,
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     if ($manageAll == true) {
         $proceed = true;
     }
-    else if ($values['enrolmentMethod'] == 'schoolMentor' && $values['gibbonPersonIDSchoolMentor'] == $_SESSION[$guid]['gibbonPersonID']) {
+    else if ($values['enrolmentMethod'] == 'schoolMentor' && $values['gibbonPersonIDSchoolMentor'] == $gibbon->session->get('gibbonPersonID')) {
         $proceed = true;
     } else {
         $learningAreas = getLearningAreas($connection2, $guid, true);
@@ -114,7 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     //Check to see if class is in one teacher teachers
     if ($values['enrolmentMethod'] == 'class') { //Is teacher of this class?
         try {
-            $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $values['gibbonCourseClassID']);
+            $dataClasses = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'gibbonCourseClassID' => $values['gibbonCourseClassID']);
             $sqlClasses = "SELECT gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND role='Teacher'";
             $resultClasses = $connection2->prepare($sqlClasses);
             $resultClasses->execute($dataClasses);

--- a/Free Learning/units_browse_details_approvalProcess.php
+++ b/Free Learning/units_browse_details_approvalProcess.php
@@ -42,12 +42,12 @@ $view = $_GET['view'] ?? '';
 if ($view != 'grid' and $view != 'map') {
     $view = 'list';
 }
-$gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 if ($canManage and isset($_GET['gibbonPersonID'])) {
     $gibbonPersonID = $_GET['gibbonPersonID'];
 }
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false and !$canManage) {
     //Fail 0
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $URL .= '&return=error0';
         header("Location: {$URL}");
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
         $freeLearningUnitID = $_POST['freeLearningUnitID'];
         $freeLearningUnitStudentID = $_POST['freeLearningUnitStudentID'];
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 //Check to see if class is in one teacher teachers
                 if ($row['enrolmentMethod'] == 'class') { //Is teacher of this class?
                     try {
-                        $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
+                        $dataClasses = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
                         $sqlClasses = "SELECT gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND role='Teacher'";
                         $resultClasses = $connection2->prepare($sqlClasses);
                         $resultClasses->execute($dataClasses);
@@ -208,7 +208,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 'exemplarWorkLicense' => $exemplarWorkLicense,
                                 'exemplarWorkEmbed' => $exemplarWorkEmbed,
                                 'commentApproval' => $commentApproval,
-                                'gibbonPersonIDApproval' => $_SESSION[$guid]['gibbonPersonID'],
+                                'gibbonPersonIDApproval' => $gibbon->session->get('gibbonPersonID'),
                                 'timestampCompleteApproved' => date('Y-m-d H:i:s')
                             ];
 
@@ -255,7 +255,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                             //Write to database
                             $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
                             try {
-                                $data = array('status' => $status, 'exemplarWork' => $exemplarWork, 'exemplarWorkThumb' => '', 'exemplarWorkLicense' => '', 'commentApproval' => $commentApproval, 'commentApproval' => $commentApproval, 'gibbonPersonIDApproval' => $_SESSION[$guid]['gibbonPersonID'], 'timestampCompleteApproved' => date('Y-m-d H:i:s'));
+                                $data = array('status' => $status, 'exemplarWork' => $exemplarWork, 'exemplarWorkThumb' => '', 'exemplarWorkLicense' => '', 'commentApproval' => $commentApproval, 'commentApproval' => $commentApproval, 'gibbonPersonIDApproval' => $gibbon->session->get('gibbonPersonID'), 'timestampCompleteApproved' => date('Y-m-d H:i:s'));
                                 if ($collaborativeAssessment == 'Y' AND  !empty($row['collaborationKey'])) {
                                     $data['collaborationKey'] = $row['collaborationKey'];
                                     $sql = 'UPDATE freeLearningUnitStudent SET exemplarWork=:exemplarWork, exemplarWorkThumb=:exemplarWorkThumb, exemplarWorkLicense=:exemplarWorkLicense, status=:status, commentApproval=:commentApproval, gibbonPersonIDApproval=:gibbonPersonIDApproval, timestampCompleteApproved=:timestampCompleteApproved WHERE collaborationKey=:collaborationKey';

--- a/Free Learning/units_browse_details_commentProcess.php
+++ b/Free Learning/units_browse_details_commentProcess.php
@@ -42,7 +42,7 @@ $urlParams = [
     'gibbonPersonID'            => $gibbonPersonID,
 ];
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&tab=1&'.http_build_query($urlParams);
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&tab=1&'.http_build_query($urlParams);
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false) {
     $URL .= '&return=error0';
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     $unitStudentGateway = $container->get(UnitStudentGateway::class);
     $discussionGateway = $container->get(DiscussionGateway::class);
     $collaborativeAssessment = getSettingByScope($connection2, 'Free Learning', 'collaborativeAssessment');
-    $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+    $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
     // Validate the required values
     if (empty($freeLearningUnitID) || empty($freeLearningUnitStudentID) || empty($comment)) {
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $event->setActionLink("/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID=$freeLearningUnitID&sidebar=true&tab=1");
         $event->addRecipient($values['gibbonPersonIDStudent']);
 
-        $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details_approval.php&'.http_build_query($urlParams);
+        $URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details_approval.php&'.http_build_query($urlParams);
 
     } else {
         $event->addScope('gibbonPersonIDStudent', $values['gibbonPersonIDStudent']);

--- a/Free Learning/units_browse_details_completePendingProcess.php
+++ b/Free Learning/units_browse_details_completePendingProcess.php
@@ -26,7 +26,7 @@ require_once '../../gibbon.php';
 
 $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 
-$highestAction = getHighestGroupedAction($guid, $_SESSION[$guid]['address'], $connection2);
+$highestAction = getHighestGroupedAction($guid, $gibbon->session->get('address'), $connection2);
 
 //Get params
 $freeLearningUnitID = $_REQUEST['freeLearningUnitID'] ?? '';
@@ -44,9 +44,9 @@ if ($view != 'grid' and $view != 'map') {
 }
 $gibbonPersonID = $canManage && isset($_GET['gibbonPersonID'])
     ? $_GET['gibbonPersonID']
-    : $_SESSION[$guid]['gibbonPersonID'];
+    : $gibbon->session->get('gibbonPersonID');
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$freeLearningUnitID.'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=1&view='.$view;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_browse_details.php&freeLearningUnitID='.$freeLearningUnitID.'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=1&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false) {
     // Fail 0
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $URL .= '&return=error6';
         header("Location: {$URL}");
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
         if ($highestAction == false || empty($roleCategory)) {
             // Fail 0
             $URL .= '&return=error0';
@@ -153,7 +153,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                     $file = $_FILES['file'] ?? null;
 
                                     // Upload the file, return the /uploads relative path
-                                    $location = $fileUploader->uploadFromPost($file, $_SESSION[$guid]['username']);
+                                    $location = $fileUploader->uploadFromPost($file, $gibbon->session->get('username'));
 
                                     if (empty($location)) {
                                         $partialFail = true;

--- a/Free Learning/units_browse_details_delete.php
+++ b/Free Learning/units_browse_details_delete.php
@@ -39,7 +39,7 @@ $view = $_GET['view'] ?? '';
 if ($view != 'grid' and $view != 'map') {
     $view = 'list';
 }
-$gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 if ($canManage and isset($_GET['gibbonPersonID'])) {
     $gibbonPersonID = $_GET['gibbonPersonID'];
 }
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     if ($highestAction == false) {
         $page->addError(__('The highest grouped action cannot be determined.'));
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
 
         if (isset($_GET['return'])) {
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 if ($manageAll == true) {
                     $proceed = true;
                 }
-                else if ($row['enrolmentMethod'] == 'schoolMentor' && $row['gibbonPersonIDSchoolMentor'] == $_SESSION[$guid]['gibbonPersonID']) {
+                else if ($row['enrolmentMethod'] == 'schoolMentor' && $row['gibbonPersonIDSchoolMentor'] == $gibbon->session->get('gibbonPersonID')) {
                     $proceed = true;
                 } else {
                     $learningAreas = getLearningAreas($connection2, $guid, true);
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 //Check to see if class is in one teacher teachers
                 if ($row['enrolmentMethod'] == 'class') { //Is teacher of this class?
                     try {
-                        $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
+                        $dataClasses = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
                         $sqlClasses = "SELECT gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND role='Teacher'";
                         $resultClasses = $connection2->prepare($sqlClasses);
                         $resultClasses->execute($dataClasses);
@@ -120,7 +120,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 } else {
                     //Let's go!
                     ?>
-					<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/units_browse_details_deleteProcess.php?freeLearningUnitStudentID=$freeLearningUnitStudentID&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view" ?>">
+					<form method="post" action="<?php echo $gibbon->session->get('absoluteURL').'/modules/'.$gibbon->session->get('module')."/units_browse_details_deleteProcess.php?freeLearningUnitStudentID=$freeLearningUnitStudentID&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view" ?>">
 						<table class='smallIntBorder' cellspacing='0' style="width: 100%">
 							<tr>
 								<td>
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 								<td>
 									<input name="freeLearningUnitStudentID" id="freeLearningUnitStudentID" value="<?php echo $freeLearningUnitStudentID ?>" type="hidden">
 									<input name="freeLearningUnitID" id="freeLearningUnitID" value="<?php echo $freeLearningUnitID ?>" type="hidden">
-									<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
+									<input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
 									<input type="submit" value="<?php echo __($guid, 'Yes'); ?>">
 								</td>
 								<td class="right">

--- a/Free Learning/units_browse_details_deleteProcess.php
+++ b/Free Learning/units_browse_details_deleteProcess.php
@@ -36,14 +36,14 @@ $view = $_GET['view'] ?? '';
 if ($view != 'grid' and $view != 'map') {
     $view = 'list';
 }
-$gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 if ($canManage and isset($_GET['gibbonPersonID'])) {
     $gibbonPersonID = $_GET['gibbonPersonID'];
 }
 
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details_delete.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
-$URLDelete = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details_delete.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
+$URLDelete = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&freeLearningUnitStudentID='.$_POST['freeLearningUnitStudentID'].'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&sidebar=true&tab=2&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details_delete.php') == false and !$canManage) {
     //Fail 0
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $URL .= '&return=error0';
         header("Location: {$URL}");
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
         $freeLearningUnitID = $_POST['freeLearningUnitID'];
         $freeLearningUnitStudentID = $_POST['freeLearningUnitStudentID'];
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 //Check to see if class is in one teacher teachers
                 if ($row['enrolmentMethod'] == 'class') { //Is teacher of this class?
                     try {
-                        $dataClasses = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
+                        $dataClasses = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'gibbonCourseClassID' => $row['gibbonCourseClassID']);
                         $sqlClasses = "SELECT gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND role='Teacher'";
                         $resultClasses = $connection2->prepare($sqlClasses);
                         $resultClasses->execute($dataClasses);

--- a/Free Learning/units_browse_details_enrol.php
+++ b/Free Learning/units_browse_details_enrol.php
@@ -29,8 +29,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 } else {
     // Check ability to enrol
     $proceed = false;
-    $gibbonSchoolYearID = $_SESSION[$guid]['gibbonSchoolYearID'];
-    $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+    $gibbonSchoolYearID = $gibbon->session->get('gibbonSchoolYearID');
+    $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 
     if ($highestAction == 'Browse Units_all') {
         $proceed = true;

--- a/Free Learning/units_browse_details_enrolMultiple.php
+++ b/Free Learning/units_browse_details_enrolMultiple.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     if ($highestAction == false) {
         $page->addError(__('The highest grouped action cannot be determined.'));
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
         //Get params
         $freeLearningUnitID = $_GET['freeLearningUnitID'] ?? '';
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         if ($view != 'grid' and $view != 'map') {
             $view = 'list';
         }
-        $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+        $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
         if ($canManage and isset($_GET['gibbonPersonID'])) {
             $gibbonPersonID = $_GET['gibbonPersonID'];
         }
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             echo '</div>';
         } else {
             try {
-                $unitList = getUnitList($connection2, $guid, $_SESSION[$guid]['gibbonPersonID'], $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
+                $unitList = getUnitList($connection2, $guid, $gibbon->session->get('gibbonPersonID'), $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
                 $data = $unitList[0];
                 $sql = $unitList[1];
                 $result = $connection2->prepare($sql);
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                 }
                 ?>
 
-                <form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/units_browse_details_enrolMultipleProcess.php?freeLearningUnitID='.$_GET['freeLearningUnitID']."&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view" ?>">
+                <form method="post" action="<?php echo $gibbon->session->get('absoluteURL').'/modules/'.$gibbon->session->get('module').'/units_browse_details_enrolMultipleProcess.php?freeLearningUnitID='.$_GET['freeLearningUnitID']."&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view" ?>">
                     <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                         <tr>
                             <td>
@@ -109,10 +109,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                     <?php
                                     try {
                                         if ($highestAction2 == 'Manage Units_all') {
-                                            $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                                            $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                                             $sqlSelect = 'SELECT gibbonCourseClassID, gibbonCourse.name, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY course, class';
                                         } else {
-                                            $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                                            $dataSelect = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
                                             $sqlSelect = "SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.name, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE role='Teacher' AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID ORDER BY course, class";
                                         }
                                         $resultSelect = $connection2->prepare($sqlSelect);
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 <select multiple name="gibbonPersonIDMulti[]" id="gibbonPersonIDMulti" style="width: 302px; height:150px">
                                     <?php
                                     try {
-                                        $dataSelect2 = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                                        $dataSelect2 = array('gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                                         $sqlSelect2 = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, gibbonRollGroup.name AS name, gibbonCourseClassID FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Student' AND status='FULL' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name, surname, preferredName";
                                         $resultSelect2 = $connection2->prepare($sqlSelect2);
                                         $resultSelect2->execute($dataSelect2);
@@ -167,7 +167,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 <span style="font-size: 90%"><i>* <?php echo __($guid, 'denotes a required field'); ?></i></span>
                             </td>
                             <td class="right">
-                                <input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
+                                <input type="hidden" name="address" value="<?php echo $gibbon->session->get('address') ?>">
                                 <input type="submit" value="<?php echo __($guid, 'Next') ?>">
                             </td>
                         </tr>

--- a/Free Learning/units_browse_details_enrolMultipleProcess.php
+++ b/Free Learning/units_browse_details_enrolMultipleProcess.php
@@ -36,13 +36,13 @@ $view = $_GET['view'] ?? '';
 if ($view != 'grid' and $view != 'map') {
     $view = 'list';
 }
-$gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 if ($canManage and isset($_GET['gibbonPersonID'])) {
     $gibbonPersonID = $_GET['gibbonPersonID'];
 }
 
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details_enrolMultiple.php&freeLearningUnitID='.$freeLearningUnitID.'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&tab=2&view='.$view;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details_enrolMultiple.php&freeLearningUnitID='.$freeLearningUnitID.'&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&tab=2&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false and !$canManage) {
     //Fail 0
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $URL .= '&updateReturn=error0';
         header("Location: {$URL}");
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
         $freeLearningUnitID = $_GET['freeLearningUnitID'] ?? '';
 
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             header("Location: {$URL}");
         } else {
             try {
-                $unitList = getUnitList($connection2, $guid, $_SESSION[$guid]['gibbonPersonID'], $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
+                $unitList = getUnitList($connection2, $guid, $gibbon->session->get('gibbonPersonID'), $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
                 $data = $unitList[0];
                 $sql = $unitList[1];
                 $result = $connection2->prepare($sql);
@@ -119,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                         foreach ($gibbonPersonIDMulti as $gibbonPersonID) {
                             //Write to database
                             try {
-                                $data = array('gibbonPersonID' => $gibbonPersonID, 'freeLearningUnitID' => $freeLearningUnitID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonCourseClassID' => $gibbonCourseClassID, 'grouping' => 'Individual', 'status' => $status);
+                                $data = array('gibbonPersonID' => $gibbonPersonID, 'freeLearningUnitID' => $freeLearningUnitID, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonCourseClassID' => $gibbonCourseClassID, 'grouping' => 'Individual', 'status' => $status);
                                 $sql = 'INSERT INTO freeLearningUnitStudent SET gibbonPersonIDStudent=:gibbonPersonID, freeLearningUnitID=:freeLearningUnitID, gibbonSchoolYearID=:gibbonSchoolYearID, gibbonCourseClassID=:gibbonCourseClassID, `grouping`=:grouping, status=:status';
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);

--- a/Free Learning/units_browse_details_enrolProcess.php
+++ b/Free Learning/units_browse_details_enrolProcess.php
@@ -39,13 +39,13 @@ $view = $_GET['view'] ?? '';
 if ($view != 'grid' and $view != 'map') {
     $view = 'list';
 }
-$gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
 if ($canManage and isset($_GET['gibbonPersonID'])) {
     $gibbonPersonID = $_GET['gibbonPersonID'];
 }
 
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&sidebar=true&tab=1&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&view='.$view;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_browse_details.php&freeLearningUnitID='.$_POST['freeLearningUnitID'].'&sidebar=true&tab=1&gibbonDepartmentID='.$gibbonDepartmentID.'&difficulty='.$difficulty.'&name='.$name.'&showInactive='.$showInactive.'&view='.$view;
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse_details.php') == false and !$canManage) {
     //Fail 0
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
         $URL .= '&return=error0';
         header("Location: {$URL}");
     } else {
-        $roleCategory = getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2);
+        $roleCategory = getRoleCategory($gibbon->session->get('gibbonRoleIDCurrent'), $connection2);
 
         $freeLearningUnitID = $_POST['freeLearningUnitID'];
 
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             header("Location: {$URL}");
         } else {
             try {
-                $unitList = getUnitList($connection2, $guid, $_SESSION[$guid]['gibbonPersonID'], $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
+                $unitList = getUnitList($connection2, $guid, $gibbon->session->get('gibbonPersonID'), $roleCategory, $highestAction, null, null, null, $showInactive, $publicUnits, $freeLearningUnitID, null);
                 $data = $unitList[0];
                 $sql = $unitList[1];
                 $result = $connection2->prepare($sql);
@@ -97,7 +97,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                         $proceed = true;
                     } else {
                         $prerequisitesActive = prerequisitesRemoveInactive($connection2, $row['freeLearningUnitIDPrerequisiteList']);
-                        $prerequisitesMet = prerequisitesMet($connection2, $_SESSION[$guid]['gibbonPersonID'], $prerequisitesActive, true);
+                        $prerequisitesMet = prerequisitesMet($connection2, $gibbon->session->get('gibbonPersonID'), $prerequisitesActive, true);
                         if ($prerequisitesMet) {
                             $proceed = true;
                         }
@@ -126,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                     } elseif ($enrolmentMethod == 'schoolMentor') {
                         $gibbonPersonIDSchoolMentor = $_POST['gibbonPersonIDSchoolMentor'];
                         try {
-                            $dataInternal = array('freeLearningUnitID3' => $freeLearningUnitID, 'gibbonPersonID2' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonPersonIDSchoolMentor1' => $gibbonPersonIDSchoolMentor);
+                            $dataInternal = array('freeLearningUnitID3' => $freeLearningUnitID, 'gibbonPersonID2' => $gibbon->session->get('gibbonPersonID'), 'gibbonPersonIDSchoolMentor1' => $gibbonPersonIDSchoolMentor);
                             $sqlInternal = "(SELECT DISTINCT gibbonPerson.gibbonPersonID, gibbonPerson.preferredName, gibbonPerson.surname
                                 FROM gibbonPerson
                                     JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonPersonID=gibbonPerson.gibbonPersonID)
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                     AND gibbonPerson.gibbonPersonID=:gibbonPersonIDSchoolMentor1
                                 )";
                             if ($row['schoolMentorCompletors'] == 'Y') {
-                                $dataInternal['gibbonPersonID1'] = $_SESSION[$guid]['gibbonPersonID'];
+                                $dataInternal['gibbonPersonID1'] = $gibbon->session->get('gibbonPersonID');
                                 $dataInternal['freeLearningUnitID1'] = $freeLearningUnitID;
                                 $dataInternal['freeLearningUnitID2'] = $freeLearningUnitID;
                                 $dataInternal['gibbonPersonIDSchoolMentor2'] = $gibbonPersonIDSchoolMentor;
@@ -276,7 +276,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                         try {
                             $whereExtra = '' ;
                             if (count($collaborators) > 0) {
-                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
                                 $collaboratorCount = 0;
                                 foreach ($collaborators AS $collaborator) {
                                     $data['gibbonPersonID'.$collaboratorCount] = $collaborator;
@@ -286,7 +286,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 $sql = 'SELECT * FROM freeLearningUnitStudent WHERE freeLearningUnitID=:freeLearningUnitID AND (gibbonPersonIDStudent=:gibbonPersonID'.$whereExtra.')';
                             }
                             else {
-                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
                                 $sql = 'SELECT * FROM freeLearningUnitStudent WHERE freeLearningUnitID=:freeLearningUnitID AND gibbonPersonIDStudent=:gibbonPersonID';
                             }
                             $result = $connection2->prepare($sql);
@@ -309,7 +309,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                             try {
                                 unset($data['freeLearningUnitID']);
                                 $whereExtra = str_replace ('gibbonPersonIDStudent', 'gibbonPersonID', $whereExtra);
-                                $sql = 'SELECT email, surname, preferredName FROM gibbonPerson WHERE (gibbonPersonID=:gibbonPersonID'.$whereExtra.') ORDER BY (gibbonPerson.gibbonPersonID=\''.$_SESSION[$guid]['gibbonPersonID'].'\') DESC, surname, preferredName';
+                                $sql = 'SELECT email, surname, preferredName FROM gibbonPerson WHERE (gibbonPersonID=:gibbonPersonID'.$whereExtra.') ORDER BY (gibbonPerson.gibbonPersonID=\''.$gibbon->session->get('gibbonPersonID').'\') DESC, surname, preferredName';
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
@@ -332,7 +332,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                 }
                                 //Write to database
                                 try {
-                                    $data = array('gibbonPersonIDStudent' => $_SESSION[$guid]['gibbonPersonID'], 'enrolmentMethod' => $enrolmentMethod, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonIDSchoolMentor' => $gibbonPersonIDSchoolMentor, 'emailExternalMentor' => $emailExternalMentor, 'nameExternalMentor' => $nameExternalMentor, 'grouping' => $grouping, 'confirmationKey' => $confirmationKey, 'collaborationKey' => $collaborationKey, 'freeLearningUnitID' => $freeLearningUnitID, 'status' => $status, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                                    $data = array('gibbonPersonIDStudent' => $gibbon->session->get('gibbonPersonID'), 'enrolmentMethod' => $enrolmentMethod, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonIDSchoolMentor' => $gibbonPersonIDSchoolMentor, 'emailExternalMentor' => $emailExternalMentor, 'nameExternalMentor' => $nameExternalMentor, 'grouping' => $grouping, 'confirmationKey' => $confirmationKey, 'collaborationKey' => $collaborationKey, 'freeLearningUnitID' => $freeLearningUnitID, 'status' => $status, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                                     $sql = "INSERT INTO freeLearningUnitStudent SET gibbonPersonIDStudent=:gibbonPersonIDStudent, enrolmentMethod=:enrolmentMethod, gibbonCourseClassID=:gibbonCourseClassID, gibbonPersonIDSchoolMentor=:gibbonPersonIDSchoolMentor, emailExternalMentor=:emailExternalMentor, nameExternalMentor=:nameExternalMentor, `grouping`=:grouping, confirmationKey=:confirmationKey, collaborationKey=:collaborationKey, freeLearningUnitID=:freeLearningUnitID, gibbonSchoolYearID=:gibbonSchoolYearID, status=:status, timestampJoined='".date('Y-m-d H:i:s')."'";
                                     $result = $connection2->prepare($sql);
                                     $result->execute($data);
@@ -354,7 +354,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
                                     foreach ($collaborators as $collaborator) {
                                         //Write to database
                                         try {
-                                            $data = array('gibbonPersonIDStudent' => $collaborator, 'enrolmentMethod' => $enrolmentMethod, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonIDSchoolMentor' => $gibbonPersonIDSchoolMentor, 'emailExternalMentor' => $emailExternalMentor, 'nameExternalMentor' => $nameExternalMentor, 'grouping' => $grouping, 'confirmationKey' => $confirmationKey, 'collaborationKey' => $collaborationKey, 'freeLearningUnitID' => $freeLearningUnitID, 'status' => $status, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                                            $data = array('gibbonPersonIDStudent' => $collaborator, 'enrolmentMethod' => $enrolmentMethod, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonIDSchoolMentor' => $gibbonPersonIDSchoolMentor, 'emailExternalMentor' => $emailExternalMentor, 'nameExternalMentor' => $nameExternalMentor, 'grouping' => $grouping, 'confirmationKey' => $confirmationKey, 'collaborationKey' => $collaborationKey, 'freeLearningUnitID' => $freeLearningUnitID, 'status' => $status, 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'));
                                             $sql = "INSERT INTO freeLearningUnitStudent SET gibbonPersonIDStudent=:gibbonPersonIDStudent, enrolmentMethod=:enrolmentMethod, gibbonCourseClassID=:gibbonCourseClassID, gibbonPersonIDSchoolMentor=:gibbonPersonIDSchoolMentor, emailExternalMentor=:emailExternalMentor, nameExternalMentor=:nameExternalMentor, `grouping`=:grouping, confirmationKey=:confirmationKey, collaborationKey=:collaborationKey, freeLearningUnitID=:freeLearningUnitID, gibbonSchoolYearID=:gibbonSchoolYearID, status=:status, timestampJoined='".date('Y-m-d H:i:s')."'";
                                             $result = $connection2->prepare($sql);
                                             $result->execute($data);

--- a/Free Learning/units_browse_details_enrol_certificate.php
+++ b/Free Learning/units_browse_details_enrol_certificate.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
     } else {
 
         try {
-            $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+            $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
             $sql = "SELECT freeLearningUnit.name, officialName, surname, preferredName, (SELECT sum(length) FROM freeLearningUnitBlock WHERE freeLearningUnitBlock.freeLearningUnitID=freeLearningUnit.freeLearningUnitID) AS length, timestampCompleteApproved
                 FROM freeLearningUnit
                     JOIN freeLearningUnitStudent ON (freeLearningUnitStudent.freeLearningUnitID=freeLearningUnit.freeLearningUnitID)
@@ -78,10 +78,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             else {
                 $output .= "<p style=\"font-style: italics; font-size: 150%; text-align: center\">on".$row['length']."</p>";
             }
-            $output .= "<h1 style=\"font-style: italics; font-size: 300%; text-align: center\">".$_SESSION[$guid]['organisationName']."</h1>";
+            $output .= "<h1 style=\"font-style: italics; font-size: 300%; text-align: center\">".$gibbon->session->get('organisationName')."</h1>";
             $output .= "<p style=\"font-style: italics; font-size: 150%; text-align: center\">Approved on ".dateConvertBack($guid, substr($row['timestampCompleteApproved'], 0, 10))."</p>";
             $output .= "<p></p><p></p>";
-            $output .= "<div style=\"margin-top: -100px; text-align: center\"><img style=\"height: 100px; width: 400px; background-color: #ffffff ; border: 1px solid #000000 ; padding: 4px ; box-shadow: 2px 2px 2px rgba(50,50,50,0.35);\" src=\"".$_SESSION[$guid]['absoluteURL'].'/'.$_SESSION[$guid]['organisationLogo']."\"/></div><br/>";
+            $output .= "<div style=\"margin-top: -100px; text-align: center\"><img style=\"height: 100px; width: 400px; background-color: #ffffff ; border: 1px solid #000000 ; padding: 4px ; box-shadow: 2px 2px 2px rgba(50,50,50,0.35);\" src=\"".$gibbon->session->get('absoluteURL').'/'.$gibbon->session->get('organisationLogo')."\"/></div><br/>";
         }
     }
 }
@@ -89,18 +89,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 //Create PDF objects
 $pdf = new TCPDF ('P', 'mm', 'A4', true, 'UTF-8', false);
 
-$fontFile = $_SESSION[$guid]['absolutePath']. '/resources/assets/fonts/DroidSansFallback.ttf';
+$fontFile = $gibbon->session->get('absolutePath'). '/resources/assets/fonts/DroidSansFallback.ttf';
 if (is_file($fontFile)) {
     $pdf->addTTFfont($fontFile, 'TrueTypeUnicode', '', 32);
 } else {
     $pdf->addTTFfont('DroidSansFallback');
 }
 
-$pdf->SetCreator($_SESSION[$guid]['organisationName']);
-$pdf->SetAuthor($_SESSION[$guid]['organisationName']);
-$pdf->SetTitle($_SESSION[$guid]['organisationName'].' Free Learning');
+$pdf->SetCreator($gibbon->session->get('organisationName'));
+$pdf->SetAuthor($gibbon->session->get('organisationName'));
+$pdf->SetTitle($gibbon->session->get('organisationName').' Free Learning');
 
-$pdf->SetHeaderData('', 0, $_SESSION[$guid]['organisationName']);
+$pdf->SetHeaderData('', 0, $gibbon->session->get('organisationName'));
 
 $pdf->setHeaderFont(Array(PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_MAIN));
 $pdf->setFooterFont(Array(PDF_FONT_NAME_DATA, '', PDF_FONT_SIZE_DATA));
@@ -126,5 +126,5 @@ $pdf->AddPage();
 $pdf->writeHTML($output, true, 0, true, 0);
 
 $pdf->lastPage();
-$pdf->Output($_SESSION[$guid]['organisationName'].' Free Learning.pdf', 'I');
+$pdf->Output($gibbon->session->get('organisationName').' Free Learning.pdf', 'I');
 ?>

--- a/Free Learning/units_browse_details_export.php
+++ b/Free Learning/units_browse_details_export.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
             $output .= '</td>';
             $output .= "<td style=\"vertical-align: top; text-align: right\" rowspan=\"8\">";
             if ($row['logo'] == null) {
-                $output .= "<img style=\"margin: 5px; height: 125px; width: 125px; background-color: #ffffff ; border: 1px solid #000000 ; padding: 4px ; box-shadow: 2px 2px 2px rgba(50,50,50,0.35);\" src=\"".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/anonymous_125.jpg\"/><br/>";
+                $output .= "<img style=\"margin: 5px; height: 125px; width: 125px; background-color: #ffffff ; border: 1px solid #000000 ; padding: 4px ; box-shadow: 2px 2px 2px rgba(50,50,50,0.35);\" src=\"".$gibbon->session->get('absoluteURL').'/themes/'.$gibbon->session->get('gibbonThemeName')."/img/anonymous_125.jpg\"/><br/>";
             } else {
                 $output .= "<img style=\"margin: 5px; height: 125px; width: 125px; background-color: #ffffff ; border: 1px solid #000000 ; padding: 4px ; box-shadow: 2px 2px 2px rgba(50,50,50,0.35);\" src=\"".$row['logo']."\"/><br/>";
             }
@@ -237,18 +237,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_browse
 
 //Create PDF objects
 $pdf = new TCPDF ('P', 'mm', 'A4', true, 'UTF-8', false);
-$fontFile = $_SESSION[$guid]['absolutePath']. '/resources/assets/fonts/DroidSansFallback.ttf';
+$fontFile = $gibbon->session->get('absolutePath'). '/resources/assets/fonts/DroidSansFallback.ttf';
 if (is_file($fontFile)) {
     $pdf->addTTFfont($fontFile, 'TrueTypeUnicode', '', 32);
 } else {
     $pdf->addTTFfont('DroidSansFallback');
 }
 
-$pdf->SetCreator($_SESSION[$guid]['organisationName']);
-$pdf->SetAuthor($_SESSION[$guid]['organisationName']);
-$pdf->SetTitle($_SESSION[$guid]['organisationName'].' Free Learning');
+$pdf->SetCreator($gibbon->session->get('organisationName'));
+$pdf->SetAuthor($gibbon->session->get('organisationName'));
+$pdf->SetTitle($gibbon->session->get('organisationName').' Free Learning');
 
-$pdf->SetHeaderData('', 0, $_SESSION[$guid]['organisationName'], 'Free Learning Unit Export');
+$pdf->SetHeaderData('', 0, $gibbon->session->get('organisationName'), 'Free Learning Unit Export');
 
 $pdf->setHeaderFont(Array(PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_MAIN));
 $pdf->setFooterFont(Array(PDF_FONT_NAME_DATA, '', PDF_FONT_SIZE_DATA));
@@ -274,5 +274,5 @@ $pdf->AddPage();
 $pdf->writeHTML($output, true, 0, true, 0);
 
 $pdf->lastPage();
-$pdf->Output($_SESSION[$guid]['organisationName'].' Free Learning', 'I');
+$pdf->Output($gibbon->session->get('organisationName').' Free Learning', 'I');
 ?>

--- a/Free Learning/units_manage_add.php
+++ b/Free Learning/units_manage_add.php
@@ -45,15 +45,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
              ->add(__m('Add Unit'));
 
 
-        $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/units_manage_addProcess.php?gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view");
+        $form = Form::create('action', $gibbon->session->get('absoluteURL').'/modules/'.$gibbon->session->get('module')."/units_manage_addProcess.php?gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view");
         $form->setFactory(DatabaseFormFactory::create($pdo));
 
-        $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+        $form->addHiddenValue('address', $gibbon->session->get('address'));
 
         $returns = array();
         $editLink = '';
         if (isset($_GET['editID'])) {
-            $editLink = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_manage_edit.php&freeLearningUnitID='.$_GET['editID'].'&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
+            $editLink = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage_edit.php&freeLearningUnitID='.$_GET['editID'].'&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
         }
         if (isset($_GET['return'])) {
             returnProcess($guid, $_GET['return'], $editLink, $returns);
@@ -61,12 +61,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
 
         if ($gibbonDepartmentID != '' or $difficulty != '' or $name != '') {
             echo "<div class='linkTop'>";
-            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_manage.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view'>".__($guid, 'Back to Search Results').'</a>';
+            echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_manage.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view'>".__($guid, 'Back to Search Results').'</a>';
             echo '</div>';
         }
 
         ?>
-        <form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/units_manage_addProcess.php?address='.$_GET['q']."&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view" ?>"  enctype="multipart/form-data">
+        <form method="post" action="<?php echo $gibbon->session->get('absoluteURL').'/modules/'.$gibbon->session->get('module').'/units_manage_addProcess.php?address='.$_GET['q']."&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&view=$view" ?>"  enctype="multipart/form-data">
             <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                 <tr class='break'>
                     <td colspan=2>
@@ -499,8 +499,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                                                 /* Unit type control */
                                                 $(document).ready(function(){
                                                     $("#new").click(function(){
-                                                        $("#sortable").append('<div id=\'blockOuter' + count + '\' class=\'blockOuter\'><img style=\'margin: 10px 0 5px 0\' src=\'<?php echo $_SESSION[$guid]['absoluteURL'] ?>/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');
-                                                        $("#blockOuter" + count).load("<?php echo $_SESSION[$guid]['absoluteURL'] ?>/modules/Free%20Learning/units_manage_add_blockAjax.php","id=" + count) ;
+                                                        $("#sortable").append('<div id=\'blockOuter' + count + '\' class=\'blockOuter\'><img style=\'margin: 10px 0 5px 0\' src=\'<?php echo $gibbon->session->get('absoluteURL') ?>/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');
+                                                        $("#blockOuter" + count).load("<?php echo $gibbon->session->get('absoluteURL') ?>/modules/Free%20Learning/units_manage_add_blockAjax.php","id=" + count) ;
                                                         count++ ;
                                                      });
                                                 });

--- a/Free Learning/units_manage_addProcess.php
+++ b/Free Learning/units_manage_addProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 require_once '../../gibbon.php';
 
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['address']).'/units_manage_add.php&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address']).'/units_manage_add.php&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage_add.php') == false) {
     //Fail 0
@@ -126,11 +126,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                     }
                 }
                 if ($attachment != null) {
-                    $attachment = $_SESSION[$guid]['absoluteURL'].'/'.$attachment;
+                    $attachment = $gibbon->session->get('absoluteURL').'/'.$attachment;
                 }
 
                 // Write to database
-                $data = array('name' => $name, 'course' => $course, 'logo' => $attachment, 'difficulty' => $difficulty, 'blurb' => $blurb, 'license' => $license, 'availableStudents'=>$availableStudents, 'availableStaff'=>$availableStaff, 'availableParents'=>$availableParents, 'availableOther' => $availableOther, 'sharedPublic' => $sharedPublic, 'active' => $active, 'gibbonYearGroupIDMinimum' => $gibbonYearGroupIDMinimum, 'grouping' => $grouping, 'gibbonDepartmentIDList' => $gibbonDepartmentIDList, 'freeLearningUnitIDPrerequisiteList' => $freeLearningUnitIDPrerequisiteList, 'schoolMentorCompletors' => $schoolMentorCompletors, 'schoolMentorCustom' => $schoolMentorCustom, 'schoolMentorCustomRole' => $schoolMentorCustomRole, 'outline' => $outline, 'gibbonPersonIDCreator' => $_SESSION[$guid]['gibbonPersonID'], 'timestamp' => date('Y-m-d H:i:s'));
+                $data = array('name' => $name, 'course' => $course, 'logo' => $attachment, 'difficulty' => $difficulty, 'blurb' => $blurb, 'license' => $license, 'availableStudents'=>$availableStudents, 'availableStaff'=>$availableStaff, 'availableParents'=>$availableParents, 'availableOther' => $availableOther, 'sharedPublic' => $sharedPublic, 'active' => $active, 'gibbonYearGroupIDMinimum' => $gibbonYearGroupIDMinimum, 'grouping' => $grouping, 'gibbonDepartmentIDList' => $gibbonDepartmentIDList, 'freeLearningUnitIDPrerequisiteList' => $freeLearningUnitIDPrerequisiteList, 'schoolMentorCompletors' => $schoolMentorCompletors, 'schoolMentorCustom' => $schoolMentorCustom, 'schoolMentorCustomRole' => $schoolMentorCustomRole, 'outline' => $outline, 'gibbonPersonIDCreator' => $gibbon->session->get('gibbonPersonID'), 'timestamp' => date('Y-m-d H:i:s'));
                 $sql = 'INSERT INTO freeLearningUnit SET name=:name, course=:course, logo=:logo, difficulty=:difficulty, blurb=:blurb, license=:license, availableStudents=:availableStudents, availableStaff=:availableStaff, availableParents=:availableParents, availableOther=:availableOther, sharedPublic=:sharedPublic, active=:active, gibbonYearGroupIDMinimum=:gibbonYearGroupIDMinimum, `grouping`=:grouping, gibbonDepartmentIDList=:gibbonDepartmentIDList, freeLearningUnitIDPrerequisiteList=:freeLearningUnitIDPrerequisiteList, schoolMentorCompletors=:schoolMentorCompletors, schoolMentorCustom=:schoolMentorCustom, schoolMentorCustomRole=:schoolMentorCustomRole, outline=:outline, gibbonPersonIDCreator=:gibbonPersonIDCreator, timestamp=:timestamp';
                 $inserted = $pdo->insert($sql, $data);
 
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                 $AI = str_pad($inserted, 10, '0', STR_PAD_LEFT);
 
                 // Write author to database
-                $data = array('freeLearningUnitID' => $AI, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'surname' => $_SESSION[$guid]['surname'], 'preferredName' => $_SESSION[$guid]['preferredName'], 'website' => $_SESSION[$guid]['website']);
+                $data = array('freeLearningUnitID' => $AI, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'surname' => $gibbon->session->get('surname'), 'preferredName' => $gibbon->session->get('preferredName'), 'website' => $gibbon->session->get('website'));
                 $sql = 'INSERT INTO freeLearningUnitAuthor SET freeLearningUnitID=:freeLearningUnitID, gibbonPersonID=:gibbonPersonID, surname=:surname, preferredName=:preferredName, website=:website';
                 
                 $inserted = $pdo->insert($sql, $data);

--- a/Free Learning/units_manage_deleteProcess.php
+++ b/Free Learning/units_manage_deleteProcess.php
@@ -21,8 +21,8 @@ require_once '../../gibbon.php';
 
 
 $freeLearningUnitID = $_POST['freeLearningUnitID'];
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/units_manage_delete.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=".$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
-$URLDelete = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_manage.php&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/units_manage_delete.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=".$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
+$URLDelete = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/units_manage.php&gibbonDepartmentID='.$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage_delete.php') == false) {
     //Fail 0
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                 $data = array('freeLearningUnitID' => $freeLearningUnitID);
                 $sql = 'SELECT * FROM freeLearningUnit WHERE freeLearningUnitID=:freeLearningUnitID';
             } elseif ($highestAction == 'Manage Units_learningAreas') {
-                $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'freeLearningUnitID' => $freeLearningUnitID);
+                $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'freeLearningUnitID' => $freeLearningUnitID);
                 $sql = "SELECT DISTINCT freeLearningUnit.* FROM freeLearningUnit JOIN gibbonDepartment ON (freeLearningUnit.gibbonDepartmentIDList LIKE CONCAT('%', gibbonDepartment.gibbonDepartmentID, '%')) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)') AND freeLearningUnitID=:freeLearningUnitID ORDER BY difficulty, name";
             }
             $result = $connection2->prepare($sql);

--- a/Free Learning/units_manage_edit.php
+++ b/Free Learning/units_manage_edit.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                 $data = array('freeLearningUnitID' => $freeLearningUnitID);
                 $sql = 'SELECT * FROM freeLearningUnit WHERE freeLearningUnitID=:freeLearningUnitID';
             } elseif ($highestAction == 'Manage Units_learningAreas') {
-                $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'freeLearningUnitID' => $freeLearningUnitID);
+                $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'freeLearningUnitID' => $freeLearningUnitID);
                 $sql = "SELECT DISTINCT freeLearningUnit.* FROM freeLearningUnit JOIN gibbonDepartment ON (freeLearningUnit.gibbonDepartmentIDList LIKE CONCAT('%', gibbonDepartment.gibbonDepartmentID, '%')) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)') AND freeLearningUnitID=:freeLearningUnitID ORDER BY difficulty, name";
             }
             $result = $connection2->prepare($sql);
@@ -90,7 +90,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
             $row = $result->fetch();
             if ($gibbonDepartmentID != '' or $difficulty != '' or $name != '') {
                 echo "<div class='linkTop'>";
-                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_manage.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&view=$view'>".__($guid, 'Back to Search Results').'</a>';
+                echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_manage.php&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&view=$view'>".__($guid, 'Back to Search Results').'</a>';
                 echo '</div>';
             }
 
@@ -98,12 +98,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                 if ($row['active'] == 'N') $showInactive = 'Y';
 
                 echo "<div class='linkTop'>";
-                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&view=$view'>".__($guid, 'View')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'View')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/plus.png'/></a>";
+                echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_browse_details.php&sidebar=true&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&view=$view'>".__($guid, 'View')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'View')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/plus.png'/></a>";
                 echo '</div>';
             }
 
             ?>
-            <form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/units_manage_editProcess.php?freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&address=".$_GET['q'] ?>" enctype="multipart/form-data">
+            <form method="post" action="<?php echo $gibbon->session->get('absoluteURL').'/modules/'.$gibbon->session->get('module')."/units_manage_editProcess.php?freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&address=".$_GET['q'] ?>" enctype="multipart/form-data">
                 <table class='smallIntBorder' cellspacing='0' style="width: 100%">
                     <tr class='break'>
                         <td colspan=2>
@@ -631,8 +631,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                                                         }
                                                         echo "<option class='all ".$rowSelect['category']."'   value='".$rowSelect['gibbonOutcomeID']."'>".$rowSelect['name'].'</option>';
                                                         $switchContents .= 'case "'.$rowSelect['gibbonOutcomeID'].'": ';
-                                                        $switchContents .= "$(\"#outcome\").append('<div id=\'outcomeOuter' + outcomeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-                                                        $switchContents .= '$("#outcomeOuter" + outcomeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Free%20Learning/units_manage_add_blockOutcomeAjax.php","type=outcome&id=" + outcomeCount + "&title='.urlencode($rowSelect['name'])."\&category=".urlencode($rowSelect['category']).'&gibbonOutcomeID='.$rowSelect['gibbonOutcomeID'].'&contents='.urlencode($rowSelect['description']).'&allowOutcomeEditing='.urlencode($allowOutcomeEditing).'") ;';
+                                                        $switchContents .= "$(\"#outcome\").append('<div id=\'outcomeOuter' + outcomeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$gibbon->session->get('absoluteURL')."/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
+                                                        $switchContents .= '$("#outcomeOuter" + outcomeCount).load("'.$gibbon->session->get('absoluteURL').'/modules/Free%20Learning/units_manage_add_blockOutcomeAjax.php","type=outcome&id=" + outcomeCount + "&title='.urlencode($rowSelect['name'])."\&category=".urlencode($rowSelect['category']).'&gibbonOutcomeID='.$rowSelect['gibbonOutcomeID'].'&contents='.urlencode($rowSelect['description']).'&allowOutcomeEditing='.urlencode($allowOutcomeEditing).'") ;';
                                                         $switchContents .= 'outcomeCount++ ;';
                                                         $switchContents .= "$('#newOutcome').val('0');";
                                                         $switchContents .= 'break;';
@@ -672,8 +672,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                                                         }
                                                         echo "<option class='all ".$rowSelect['category']."'   value='".$rowSelect['gibbonOutcomeID']."'>".$rowSelect['name'].'</option>';
                                                         $switchContents .= 'case "'.$rowSelect['gibbonOutcomeID'].'": ';
-                                                        $switchContents .= "$(\"#outcome\").append('<div id=\'outcomeOuter' + outcomeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL']."/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-                                                        $switchContents .= '$("#outcomeOuter" + outcomeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Free%20Learning/units_manage_add_blockOutcomeAjax.php","type=outcome&id=" + outcomeCount + "&title='.urlencode($rowSelect['name'])."\&category=".urlencode($rowSelect['category']).'&gibbonOutcomeID='.$rowSelect['gibbonOutcomeID'].'&contents='.urlencode($rowSelect['description']).'&allowOutcomeEditing='.urlencode($allowOutcomeEditing).'") ;';
+                                                        $switchContents .= "$(\"#outcome\").append('<div id=\'outcomeOuter' + outcomeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$gibbon->session->get('absoluteURL')."/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
+                                                        $switchContents .= '$("#outcomeOuter" + outcomeCount).load("'.$gibbon->session->get('absoluteURL').'/modules/Free%20Learning/units_manage_add_blockOutcomeAjax.php","type=outcome&id=" + outcomeCount + "&title='.urlencode($rowSelect['name'])."\&category=".urlencode($rowSelect['category']).'&gibbonOutcomeID='.$rowSelect['gibbonOutcomeID'].'&contents='.urlencode($rowSelect['description']).'&allowOutcomeEditing='.urlencode($allowOutcomeEditing).'") ;';
                                                         $switchContents .= 'outcomeCount++ ;';
                                                         $switchContents .= "$('#newOutcome').val('0');";
                                                         $switchContents .= 'break;';
@@ -798,8 +798,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                                                     var count=<?php echo $resultBlocks->rowCount() + 1 ?> ;
                                                     $(document).ready(function(){
                                                         $("#new").click(function(){
-                                                            $("#sortable").append('<div id=\'blockOuter' + count + '\' class=\'blockOuter\'><img style=\'margin: 10px 0 5px 0\' src=\'<?php echo $_SESSION[$guid]['absoluteURL'] ?>/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');
-                                                            $("#blockOuter" + count).load("<?php echo $_SESSION[$guid]['absoluteURL'] ?>/modules/Free%20Learning/units_manage_add_blockAjax.php","id=" + count + "&mode=masterEdit") ;
+                                                            $("#sortable").append('<div id=\'blockOuter' + count + '\' class=\'blockOuter\'><img style=\'margin: 10px 0 5px 0\' src=\'<?php echo $gibbon->session->get('absoluteURL') ?>/themes/Default/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');
+                                                            $("#blockOuter" + count).load("<?php echo $gibbon->session->get('absoluteURL') ?>/modules/Free%20Learning/units_manage_add_blockAjax.php","id=" + count + "&mode=masterEdit") ;
                                                             count++ ;
                                                          });
                                                     });

--- a/Free Learning/units_manage_editProcess.php
+++ b/Free Learning/units_manage_editProcess.php
@@ -21,7 +21,7 @@ require_once '../../gibbon.php';
 
 
 $freeLearningUnitID = $_GET['freeLearningUnitID'];
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['address'])."/units_manage_edit.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=".$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address'])."/units_manage_edit.php&freeLearningUnitID=$freeLearningUnitID&gibbonDepartmentID=".$_GET['gibbonDepartmentID'].'&difficulty='.$_GET['difficulty'].'&name='.$_GET['name'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage_edit.php') == false) {
     //Fail 0
@@ -118,7 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                         $data = array('freeLearningUnitID' => $freeLearningUnitID);
                         $sql = 'SELECT * FROM freeLearningUnit WHERE freeLearningUnitID=:freeLearningUnitID';
                     } elseif ($highestAction == 'Manage Units_learningAreas') {
-                        $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'freeLearningUnitID' => $freeLearningUnitID);
+                        $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'freeLearningUnitID' => $freeLearningUnitID);
                         $sql = "SELECT DISTINCT freeLearningUnit.* FROM freeLearningUnit JOIN gibbonDepartment ON (freeLearningUnit.gibbonDepartmentIDList LIKE CONCAT('%', gibbonDepartment.gibbonDepartmentID, '%')) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)') AND freeLearningUnitID=:freeLearningUnitID ORDER BY difficulty, name";
                     }
                     $result = $connection2->prepare($sql);
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                         }
 
                         if ($attachment != null) {
-                            $attachment = $_SESSION[$guid]['absoluteURL'].'/'.$attachment;
+                            $attachment = $gibbon->session->get('absoluteURL').'/'.$attachment;
                         }
                     } else {
                         $attachment = $row['logo'];
@@ -177,7 +177,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                     //Write author to database for major edits only
                     if ($majorEdit == 'Y') {
                         try {
-                            $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                            $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'));
                             $sql = 'SELECT * FROM freeLearningUnitAuthor WHERE freeLearningUnitID=:freeLearningUnitID AND gibbonPersonID=:gibbonPersonID';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
                         }
                         if ($result->rowCount() < 1) {
                             try {
-                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'surname' => $_SESSION[$guid]['surname'], 'preferredName' => $_SESSION[$guid]['preferredName'], 'website' => $_SESSION[$guid]['website']);
+                                $data = array('freeLearningUnitID' => $freeLearningUnitID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'surname' => $gibbon->session->get('surname'), 'preferredName' => $gibbon->session->get('preferredName'), 'website' => $gibbon->session->get('website'));
                                 $sql = 'INSERT INTO freeLearningUnitAuthor SET freeLearningUnitID=:freeLearningUnitID, gibbonPersonID=:gibbonPersonID, surname=:surname, preferredName=:preferredName, website=:website';
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);

--- a/Free Learning/units_mentor.php
+++ b/Free Learning/units_mentor.php
@@ -25,9 +25,9 @@ $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 $highestAction = false;
 $canManage = false;
 $gibbonPersonID ='';
-if (isset($_SESSION[$guid]['gibbonPersonID'])) {
+if ($gibbon->session->exists('gibbonPersonID')) {
     $highestAction = getHighestGroupedAction($guid, '/modules/Free Learning/units_browse.php', $connection2);
-    $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+    $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
     $canManage = false;
     if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') and $highestAction == 'Browse Units_all') {
         $canManage = true;
@@ -58,7 +58,7 @@ if (isset($_GET['return'])) {
     returnProcess($guid, $_GET['return'], null, array('success0' => __($guid, 'Your request was completed successfully. Thank you for your time.', 'Free Learning'), 'success1' => __($guid, 'Your request was completed successfully. Thank you for your time. The learners you are helping will be in touch in due course: in the meanwhile, no further action is required on your part.', 'Free Learning')));
 }
 
-if ($freeLearningUnitID != '' && isset($_SESSION[$guid]['gibbonPersonID'])) {
+if ($freeLearningUnitID != '' && $gibbon->session->exists('gibbonPersonID')) {
     //Check unit
     try {
         $data = array('freeLearningUnitID' => $freeLearningUnitID) ;
@@ -83,7 +83,7 @@ if ($freeLearningUnitID != '' && isset($_SESSION[$guid]['gibbonPersonID'])) {
         //Show choice for school mentor
         if ($mode == "internal" && $confirmationKey != '') {
             echo '<p>';
-            echo sprintf(__($guid, 'The following users at %1$s have requested your input into their %2$sFree Learning%3$s work, with the hope that you will be able to act as a "critical buddy" or mentor, offering feedback on their progress.', 'Free Learning'), $_SESSION[$guid]['systemName'], "<a target='_blank' href='http://rossparker.org'>", '</a>');
+            echo sprintf(__($guid, 'The following users at %1$s have requested your input into their %2$sFree Learning%3$s work, with the hope that you will be able to act as a "critical buddy" or mentor, offering feedback on their progress.', 'Free Learning'), $gibbon->session->get('systemName'), "<a target='_blank' href='http://rossparker.org'>", '</a>');
             echo '<br/>';
             echo '</p>';
 
@@ -115,7 +115,7 @@ if ($freeLearningUnitID != '' && isset($_SESSION[$guid]['gibbonPersonID'])) {
                 echo '</ul>';
                 echo '<p style=\'margin-top: 20px\'>';
                 echo sprintf(__($guid, 'The unit you are being asked to advise on is called %1$s and is described as follows:', 'Free Learning'), '<b>'.$row['name'].'</b>').$row['blurb']."<br/><br/>";
-                echo sprintf(__($guid, 'Please %1$sclick here%2$s if you are able to get involved, or, %3$sclick here%4$s if you not in a position to help.', 'Free Learning'), "<a class='p-1 border border-solid border-green-500 text-green-500 bg-green-200' href='".$_SESSION[$guid]['absoluteURL']."/modules/Free Learning/units_mentorProcess.php?response=Y&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey&freeLearningUnitID=$freeLearningUnitID'>", '</a>', "<a class='p-1 border border-solid border-red-500 text-red-500 bg-red-200' href='".$_SESSION[$guid]['absoluteURL']."/modules/Free Learning/units_mentorProcess.php?response=N&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey&freeLearningUnitID=$freeLearningUnitID'>", '</a>');
+                echo sprintf(__($guid, 'Please %1$sclick here%2$s if you are able to get involved, or, %3$sclick here%4$s if you not in a position to help.', 'Free Learning'), "<a class='p-1 border border-solid border-green-500 text-green-500 bg-green-200' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_mentorProcess.php?response=Y&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey&freeLearningUnitID=$freeLearningUnitID'>", '</a>', "<a class='p-1 border border-solid border-red-500 text-red-500 bg-red-200' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_mentorProcess.php?response=N&freeLearningUnitStudentID=".$freeLearningUnitStudentID."&confirmationKey=$confirmationKey&freeLearningUnitID=$freeLearningUnitID'>", '</a>');
                 echo '</p>';
             }
         }

--- a/Free Learning/units_mentorProcess.php
+++ b/Free Learning/units_mentorProcess.php
@@ -26,9 +26,9 @@ $publicUnits = getSettingByScope($connection2, 'Free Learning', 'publicUnits');
 $highestAction = false;
 $canManage = false;
 $gibbonPersonID ='';
-if (isset($_SESSION[$guid]['gibbonPersonID'])) {
+if ($gibbon->session->exists('gibbonPersonID')) {
     $highestAction = getHighestGroupedAction($guid, '/modules/Free Learning/units_browse.php', $connection2);
-    $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
+    $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
     $canManage = false;
     if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') and $highestAction == 'Browse Units_all') {
         $canManage = true;
@@ -53,12 +53,12 @@ $freeLearningUnitStudentID = $_GET['freeLearningUnitStudentID'] ?? null;
 $confirmationKey = $_GET['confirmationKey'] ?? null;
 
 //Check to see if system settings are set from databases
-if (@$_SESSION[$guid]['systemSettingsSet'] == false) {
+if (@$gibbon->session->get('systemSettingsSet') == false) {
     getSystemSettings($guid, $connection2);
 }
 
 //Set return URL
-$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Free Learning/units_mentor.php&sidebar=true&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view";
+$URL = $gibbon->session->get('absoluteURL')."/index.php?q=/modules/Free Learning/units_mentor.php&sidebar=true&gibbonDepartmentID=$gibbonDepartmentID&difficulty=$difficulty&name=$name&showInactive=$showInactive&gibbonPersonID=$gibbonPersonID&view=$view";
 
 if ($response == '' or $freeLearningUnitStudentID == '' or $confirmationKey == '') {
     $URL .= '&return=error3';

--- a/Free Learning/units_mentor_approval.php
+++ b/Free Learning/units_mentor_approval.php
@@ -93,7 +93,7 @@ if (!$block) {
                 foreach ($blocks as $block) {
                     echo $templateView->fetchFromTemplate('unitBlock.twig.html', $block + [
                         'roleCategory' => 'Staff', 
-                        'gibbonPersonID' => $_SESSION[$guid]['username'] ?? '',
+                        'gibbonPersonID' => $gibbon->session->get('username') ?? '',
                         'blockCount' => $blockCount
                     ]);
                     $resourceContents .= $block['contents'];

--- a/Free Learning/units_mentor_approvalProcess.php
+++ b/Free Learning/units_mentor_approvalProcess.php
@@ -30,7 +30,7 @@ $freeLearningUnitID = $_POST['freeLearningUnitID'] ?? null;
 $confirmationKey = $_POST['confirmationKey'] ?? null;
 
 //Set return URL
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Free Learning/units_mentor_approval.php&sidebar=true&freeLearningUnitStudentID=$freeLearningUnitStudentID&confirmationKey=$confirmationKey';
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_mentor_approval.php&sidebar=true&freeLearningUnitStudentID=$freeLearningUnitStudentID&confirmationKey=$confirmationKey';
 
 if ($freeLearningUnitStudentID == '' or $freeLearningUnitID == '' or $confirmationKey == '') {
     $URL .= '&return=error3';


### PR DESCRIPTION
Expressions like `$_SESSION[$guid]['variableName']` have been replaced with `$gibbon->session->get('variableName')`.

Also, expressions like `isset($_SESSION[$guid]['variableName'])` have been replaced with `$gibbon->session->exists('variableName')`.