### PR TITLE
v5.11.00 - Add export and import options to Manage Units

### DIFF
--- a/Free Learning/CHANGEDB.php
+++ b/Free Learning/CHANGEDB.php
@@ -1184,3 +1184,8 @@ $sql[$count][1] = "
 INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `entrySidebar`, `menuShow`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES ((SELECT gibbonModuleID FROM gibbonModule WHERE name='Free Learning'), 'Manage Enrolment_all', 0, 'Admin', 'Allows a user to manage all enrolments within Browse Units. Does not have an interface of its own.', 'enrolment_manage.php','enrolment_manage.php', 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N');end
 INSERT INTO `gibbonPermission` (`permissionID` ,`gibbonRoleID` ,`gibbonActionID`) VALUES (NULL , '1', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Free Learning' AND gibbonAction.name='Manage Enrolment_all'));end
 ";
+
+//v5.11.00
+++$count;
+$sql[$count][0] = '5.11.00';
+$sql[$count][1] = "";

--- a/Free Learning/CHANGELOG.txt
+++ b/Free Learning/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v5.11.00
+-------
+Added tools to export and import units
+
 v5.10.13
 -------
 Moved Manage Enrolment_all into its own action

--- a/Free Learning/manifest.php
+++ b/Free Learning/manifest.php
@@ -25,7 +25,7 @@ $description = "Free Learning is a module which enables a student-focused and st
 $entryURL = 'units_browse.php';
 $type = 'Additional';
 $category = 'Learn';
-$version = '5.10.13';
+$version = '5.11.00';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org/free-learning';
 

--- a/Free Learning/src/Domain/UnitAuthorGateway.php
+++ b/Free Learning/src/Domain/UnitAuthorGateway.php
@@ -1,0 +1,41 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\FreeLearning\Domain;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+class UnitAuthorGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'freeLearningUnitAuthor';
+    private static $primaryKey = 'freeLearningUnitAuthorID';
+    private static $searchableColumns = ['freeLearningUnitAuthor.surname', 'freeLearningUnitAuthor.preferredName'];
+
+    public function selectAuthorsByUnit($freeLearningUnitID)
+    {
+        $data = ['freeLearningUnitID' => $freeLearningUnitID];
+        $sql = "SELECT * FROM freeLearningUnitAuthor WHERE freeLearningUnitID=:freeLearningUnitID ORDER BY surname";
+
+        return $this->db()->select($sql, $data);
+    }
+}

--- a/Free Learning/src/Domain/UnitBlockGateway.php
+++ b/Free Learning/src/Domain/UnitBlockGateway.php
@@ -1,0 +1,41 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\FreeLearning\Domain;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+class UnitBlockGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'freeLearningUnitBlock';
+    private static $primaryKey = 'freeLearningUnitBlockID';
+    private static $searchableColumns = ['freeLearningUnitBlock.title'];
+
+    public function selectBlocksByUnit($freeLearningUnitID)
+    {
+        $data = ['freeLearningUnitID' => $freeLearningUnitID];
+        $sql = "SELECT * FROM freeLearningUnitBlock WHERE freeLearningUnitID=:freeLearningUnitID ORDER BY sequenceNumber";
+
+        return $this->db()->select($sql, $data);
+    }
+}

--- a/Free Learning/src/Domain/UnitGateway.php
+++ b/Free Learning/src/Domain/UnitGateway.php
@@ -139,6 +139,26 @@ class UnitGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
 
+    public function selectPrerequisiteNamesByIDs($freeLearningUnitIDPrerequisiteList)
+    {
+        $freeLearningUnitIDPrerequisiteList = is_array($freeLearningUnitIDPrerequisiteList) ? implode(',', $freeLearningUnitIDPrerequisiteList) : $freeLearningUnitIDPrerequisiteList;
+
+        $data = ['freeLearningUnitIDPrerequisiteList' => $freeLearningUnitIDPrerequisiteList];
+        $sql = "SELECT name FROM freeLearningUnit WHERE FIND_IN_SET(freeLearningUnitID, :freeLearningUnitIDPrerequisiteList) ORDER BY FIND_IN_SET(freeLearningUnitID, :freeLearningUnitIDPrerequisiteList)";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectPrerequisiteIDsByNames($freeLearningUnitIDPrerequisiteList)
+    {
+        $freeLearningUnitIDPrerequisiteList = is_array($freeLearningUnitIDPrerequisiteList) ? implode(',', $freeLearningUnitIDPrerequisiteList) : $freeLearningUnitIDPrerequisiteList;
+        
+        $data = ['freeLearningUnitIDPrerequisiteList' => $freeLearningUnitIDPrerequisiteList];
+        $sql = "SELECT freeLearningUnitID FROM freeLearningUnit WHERE FIND_IN_SET(name, :freeLearningUnitIDPrerequisiteList) ORDER BY FIND_IN_SET(freeLearningUnitID, :freeLearningUnitIDPrerequisiteList)";
+
+        return $this->db()->select($sql, $data);
+    }
+
     public function selectUnitPrerequisitesByPerson($gibbonPersonID)
     {
         $data = ['gibbonPersonID' => $gibbonPersonID];

--- a/Free Learning/src/UnitExporter.php
+++ b/Free Learning/src/UnitExporter.php
@@ -1,0 +1,98 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\FreeLearning;
+
+use ZipArchive;
+use Gibbon\Contracts\Services\Session;
+use Gibbon\Module\FreeLearning\Domain\UnitGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitBlockGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitAuthorGateway;
+
+class UnitExporter 
+{
+    protected $filename = 'FreeLearningUnits';
+    protected $data;
+    protected $files;
+
+    protected $unitGateway;
+    protected $unitBlockGateway;
+    protected $unitAuthorGateway;
+    protected $session;
+
+    public function __construct(UnitGateway $unitGateway, UnitBlockGateway $unitBlockGateway, UnitAuthorGateway $unitAuthorGateway, Session $session)
+    {
+        $this->unitGateway = $unitGateway;
+        $this->unitBlockGateway = $unitBlockGateway;
+        $this->unitAuthorGateway = $unitAuthorGateway;
+        $this->session = $session;
+    }
+
+    public function addUnitToExport($freeLearningUnitID)
+    {
+        $unit = $this->unitGateway->getByID($freeLearningUnitID);
+
+        if (empty($unit)) return;
+
+        if (!empty($unit['logo'])) {
+            $logoPath = $_SERVER['DOCUMENT_ROOT'] . parse_url($unit['logo'], PHP_URL_PATH);
+            $this->files[] = $logoPath;
+            $unit['logo'] = basename($logoPath);
+        }
+        
+        $this->data['units'][] = [
+            'name' => $unit['name'],
+            'unit' => $unit,
+            'blocks' => $this->unitBlockGateway->selectBlocksByUnit($freeLearningUnitID)->fetchAll(),
+            'authors' => $this->unitAuthorGateway->selectAuthorsByUnit($freeLearningUnitID)->fetchAll(),
+        ];
+    }
+
+    public function output()
+    {
+        // Create the zip archive and add contents
+        $filepath = tempnam(sys_get_temp_dir(), 'freelearning');
+        $zip = new ZipArchive();
+        $zip->open($filepath, ZipArchive::CREATE);
+
+        // Add Files
+        foreach ($this->files as $filePath) {
+            $zip->addFile($filePath, 'Units/files/'.basename($filePath));
+            $this->data['files'][] = basename($filePath);
+        }
+
+        // Add Data
+        $zip->addFromString('Units/data.json', json_encode($this->data, JSON_PRETTY_PRINT));
+
+        $zip->close();
+
+        // Stream the zip archive for downloading
+        header('Content-Description: File Transfer');
+        header('Content-Type: application/zip');
+        header('Content-Disposition: attachment; filename="'.htmlentities($this->filename).'.zip"');
+        header('Content-Transfer-Encoding: base64');
+        header('Expires: 0');
+        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+        header('Pragma: public');
+        header('Content-Length: ' . filesize($filepath));
+        echo file_get_contents($filepath);
+
+        unlink($filepath);
+    }
+}

--- a/Free Learning/src/UnitExporter.php
+++ b/Free Learning/src/UnitExporter.php
@@ -95,6 +95,7 @@ class UnitExporter
             }
         }
         
+        // Add unit details to data array
         $this->data['units'][] = [
             'name' => $unit['name'],
             'unit' => $unit,
@@ -114,13 +115,17 @@ class UnitExporter
         // Add Files
         foreach ($this->files as $file) {
             if ($file['type'] == 'url') {
-                $fileContents = file_get_contents($file['location']);
+                // Handle images from url by downloading them firsy
+                $context  = stream_context_create(['ssl' => ['verify_peer' => false]]);
+                $fileContents = file_get_contents($file['location'], false, $context);
+
                 if (empty($fileContents)) continue;
 
                 $zip->addFromString('files/'.basename($file['location']), $fileContents);
                 $this->data['files'][] = basename($file['location']);
 
             } elseif ($file['type'] == 'path') {
+                // Handle local images by adding them directly
                 if (!file_exists($file['location'])) continue;
 
                 $zip->addFile($file['location'], 'files/'.basename($file['location']));

--- a/Free Learning/src/UnitImporter.php
+++ b/Free Learning/src/UnitImporter.php
@@ -1,0 +1,143 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\FreeLearning;
+
+use ZipArchive;
+use Gibbon\Contracts\Services\Session;
+use Gibbon\Module\FreeLearning\Domain\UnitGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitBlockGateway;
+use Gibbon\Module\FreeLearning\Domain\UnitAuthorGateway;
+
+class UnitImporter 
+{
+    protected $gibbonDepartmentIDList;
+    protected $course;
+
+    protected $files;
+
+    protected $unitGateway;
+    protected $unitBlockGateway;
+    protected $unitAuthorGateway;
+    protected $session;
+
+    public function __construct(UnitGateway $unitGateway, UnitBlockGateway $unitBlockGateway, UnitAuthorGateway $unitAuthorGateway, Session $session)
+    {
+        $this->unitGateway = $unitGateway;
+        $this->unitBlockGateway = $unitBlockGateway;
+        $this->unitAuthorGateway = $unitAuthorGateway;
+        $this->session = $session;
+    }
+
+    public function setDefaults($gibbonDepartmentIDList = null, $course = null)
+    {
+        $this->gibbonDepartmentIDList = $gibbonDepartmentIDList;
+        $this->course = $course;
+    }
+
+    public function importFromFile($filePath) : bool
+    {
+        $zip = new ZipArchive();
+        $zip->open($filePath);
+
+        $json = $zip->getFromName('Units/data.json');
+
+        $data = json_decode($json, true);
+        $files = [];
+
+        if (empty($data['units'])) return false;
+
+        // Upload Files
+        foreach ($data['files'] as $filename) {
+            $uploadsFolder = 'uploads/'.date('Y').'/'.date('m');
+            $destinationPath = $this->session->get('absolutePath').'/'.$uploadsFolder.'/'.$filename;
+
+            if (@copy('zip://'.$filePath.'#Units/files/'.$filename, $destinationPath)) {
+                $files[$filename] = $this->session->get('absoluteURL').'/'.$uploadsFolder.'/'.$filename;
+            }
+        }
+
+        foreach ($data['units'] as $unit) {
+            $existingUnit = $this->unitGateway->selectBy([
+                'name' => $unit['name'],
+            ])->fetch();
+
+            // Apply default values
+            if (!empty($this->gibbonDepartmentIDList)) $unit['unit']['gibbonDepartmentIDList'] = $this->gibbonDepartmentIDList;
+            if (!empty($this->course)) $unit['unit']['course'] = $this->course;
+
+            // Get the uploaded logo URL
+            if (!empty($unit['unit']['logo'])) {
+                $unit['unit']['logo'] = $files[$unit['unit']['logo']] ?? '';
+            }
+
+            // Add or update the unit
+            if (!empty($existingUnit)) {
+                $freeLearningUnitID = $existingUnit['freeLearningUnitID'];
+                $this->unitGateway->update($freeLearningUnitID, $unit['unit']);
+            } else {
+                $freeLearningUnitID = $this->unitGateway->insert($unit['unit']);
+            }
+
+            // Add Blocks
+            foreach ($unit['blocks'] as $block) {
+                $block['freeLearningUnitID'] = $freeLearningUnitID;
+                if (!empty($existingUnit)) {
+                    $existingBlock = $this->unitBlockGateway->selectBy([
+                        'freeLearningUnitID' => $existingUnit['freeLearningUnitID'],
+                        'title' => $block['title'],
+                    ])->fetch();
+                }
+
+                if (!empty($existingBlock)) {
+                    $this->unitBlockGateway->update($existingBlock['freeLearningUnitBlockID'], $block);
+                } else {
+                    $this->unitBlockGateway->insert($block);
+                }
+            }
+
+            // Add Authors
+            foreach ($unit['authors'] as $author) {
+                $author['freeLearningUnitID'] = $freeLearningUnitID;
+                $author['gibbonPersonID'] = null;
+
+                if (!empty($existingUnit)) {
+                    $existingAuthor = $this->unitAuthorGateway->selectBy([
+                        'freeLearningUnitID' => $existingUnit['freeLearningUnitID'],
+                        'surname' => $author['surname'],
+                        'preferredName' => $author['preferredName'],
+                    ])->fetch();
+                }
+
+                if (!empty($existingAuthor)) {
+                    $this->unitAuthorGateway->update($existingAuthor['freeLearningUnitAuthorID'], $author);
+                } else {
+                    $this->unitAuthorGateway->insert($author);
+                }
+            }
+        }
+
+        $zip->close();
+
+        unlink($filePath);
+
+        return true;
+    }
+
+}

--- a/Free Learning/src/UnitImporter.php
+++ b/Free Learning/src/UnitImporter.php
@@ -56,7 +56,7 @@ class UnitImporter
         $zip = new ZipArchive();
         $zip->open($filePath);
 
-        $json = $zip->getFromName('Units/data.json');
+        $json = $zip->getFromName('data.json');
 
         $data = json_decode($json, true);
         $files = [];
@@ -68,7 +68,7 @@ class UnitImporter
             $uploadsFolder = 'uploads/'.date('Y').'/'.date('m');
             $destinationPath = $this->session->get('absolutePath').'/'.$uploadsFolder.'/'.$filename;
 
-            if (@copy('zip://'.$filePath.'#Units/files/'.$filename, $destinationPath)) {
+            if (@copy('zip://'.$filePath.'#files/'.$filename, $destinationPath)) {
                 $files[$filename] = $this->session->get('absoluteURL').'/'.$uploadsFolder.'/'.$filename;
             }
         }
@@ -87,6 +87,11 @@ class UnitImporter
                 $unit['unit']['logo'] = $files[$unit['unit']['logo']] ?? '';
             }
 
+            // Update unit outline to point to new file locations
+            foreach ($files as $filename => $url) {
+                $unit['unit']['outline'] = str_replace($filename, $url, $unit['unit']['outline']);
+            }
+
             // Add or update the unit
             if (!empty($existingUnit)) {
                 $freeLearningUnitID = $existingUnit['freeLearningUnitID'];
@@ -103,6 +108,11 @@ class UnitImporter
                         'freeLearningUnitID' => $existingUnit['freeLearningUnitID'],
                         'title' => $block['title'],
                     ])->fetch();
+                }
+
+                // Update uploaded files to point to their new file location
+                foreach ($files as $filename => $url) {
+                    $block['contents'] = str_replace($filename, $url, $block['contents']);
                 }
 
                 if (!empty($existingBlock)) {

--- a/Free Learning/units_browse_details.php
+++ b/Free Learning/units_browse_details.php
@@ -143,7 +143,9 @@ if (!(isActionAccessible($guid, $connection2, '/modules/Free Learning/units_brow
                             echo " | ";
                         }
                         if ($browseAll) {
-                            echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_browse_details_export.php?freeLearningUnitID=$freeLearningUnitID'>".__($guid, 'Export')."<img style='margin: 0 0 -4px 3px' title='".__($guid, 'Export')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/download.png'/></a>";
+                            echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_browse_details_export.php?freeLearningUnitID=$freeLearningUnitID'>".__('Download')."<img style='margin: 0 0 -4px 3px' title='".__('Download')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/download.png'/></a> | ";
+
+                            echo "<a target='_blank' href='".$gibbon->session->get('absoluteURL')."/modules/Free Learning/units_manageProcessBulk.php?action=Export&freeLearningUnitID=$freeLearningUnitID&name=".$values['name']."'>".__('Export')."<img style='margin: 0 0 -4px 3px' title='".__('Export')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/delivery2.png'/></a>";
                         }
                         echo '</div>';
                     }

--- a/Free Learning/units_manageProcessBulk.php
+++ b/Free Learning/units_manageProcessBulk.php
@@ -25,6 +25,11 @@ require_once '../../gibbon.php';
 
 $URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage.php';
 
+// Override the ini to keep this process alive
+ini_set('memory_limit', '2048M');
+ini_set('max_execution_time', 1800);
+set_time_limit(1800);
+
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
@@ -44,6 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
 
     if ($action == 'Export') {
 
+        // Export zip contents of units
         $exporter = $container->get(UnitExporter::class);
         $exporter->setFilename(!empty($name)? $name : 'FreeLearningUnits');
 

--- a/Free Learning/units_manageProcessBulk.php
+++ b/Free Learning/units_manageProcessBulk.php
@@ -1,0 +1,63 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Module\FreeLearning\UnitExporter;
+
+require_once '../../gibbon.php';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $action = $_POST['action'] ?? '';
+    $freeLearningUnitIDList = $_POST['freeLearningUnitID'] ?? [];
+    $partialFail = false;
+
+    if (empty($action)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    if ($action == 'Export') {
+
+        $exporter = $container->get(UnitExporter::class);
+
+        foreach ($freeLearningUnitIDList as $freeLearningUnitID) {
+            $exporter->addUnitToExport($freeLearningUnitID);
+        }
+
+        $exporter->output();
+        exit;
+
+    } else {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+    
+    $URL .= $partialFail
+        ? '&return=warning1'
+        : '&return=success0';
+    header("Location: {$URL}");
+
+}

--- a/Free Learning/units_manageProcessBulk.php
+++ b/Free Learning/units_manageProcessBulk.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Module\FreeLearning\UnitExporter;
 
+$_POST['address'] = '/modules/Free Learning/units_manage.php';
+
 require_once '../../gibbon.php';
 
 $URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage.php';
@@ -28,8 +30,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
     header("Location: {$URL}");
 } else {
     // Proceed!
-    $action = $_POST['action'] ?? '';
-    $freeLearningUnitIDList = $_POST['freeLearningUnitID'] ?? [];
+    $action = $_REQUEST['action'] ?? '';
+    $name = $_REQUEST['name'] ?? [];
+    $freeLearningUnitID = $_REQUEST['freeLearningUnitID'] ?? [];
+    $freeLearningUnitIDList = is_array($freeLearningUnitID) ? $freeLearningUnitID : [$freeLearningUnitID];
     $partialFail = false;
 
     if (empty($action)) {
@@ -41,6 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
     if ($action == 'Export') {
 
         $exporter = $container->get(UnitExporter::class);
+        $exporter->setFilename(!empty($name)? $name : 'FreeLearningUnits');
 
         foreach ($freeLearningUnitIDList as $freeLearningUnitID) {
             $exporter->addUnitToExport($freeLearningUnitID);

--- a/Free Learning/units_manage_import.php
+++ b/Free Learning/units_manage_import.php
@@ -1,0 +1,55 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+
+if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    $page->breadcrumbs
+        ->add(__m('Manage Units'), 'units_manage.php')
+        ->add(__m('Import Units'));
+
+    $form = Form::create('importUnits', $gibbon->session->get('absoluteURL').'/modules/Free Learning/units_manage_importProcess.php');
+    $form->setTitle(__m('Import Units'));
+    $form->setDescription(__m('This page lets you import zip archives that have been created with the unit export tool.'));
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+    $form->addHiddenValue('gibbonSchoolYearID', $gibbon->session->get('gibbonSchoolYearID'));
+
+    $row = $form->addRow();
+        $row->addLabel('file', __('ZIP File'));
+        $row->addFileUpload('file')->required();
+
+    $sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
+    $row = $form->addRow();
+        $row->addLabel('gibbonDepartmentIDList', __('Learning Areas'))->description(__m('Optionally add all units to the selected Learning Area.'));
+        $row->addSelect('gibbonDepartmentIDList')->fromQuery($pdo, $sql)->selectMultiple()->setSize(5);
+
+    $row = $form->addRow();
+        $row->addLabel('course', __m('Course'))->description(__m('Optionally add all units to the selected Course.'));
+        $row->addTextField('course');
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/Free Learning/units_manage_import.php
+++ b/Free Learning/units_manage_import.php
@@ -48,6 +48,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
         $row->addTextField('course');
 
     $row = $form->addRow();
+        $row->addLabel('override', __m('Allow override?'))->description(__m('Units with the same name will be updated with the imported content.'));
+        $row->addCheckbox('override')->setValue('Y');
+
+    $row = $form->addRow();
         $row->addFooter();
         $row->addSubmit();
 

--- a/Free Learning/units_manage_import.php
+++ b/Free Learning/units_manage_import.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
 
     $row = $form->addRow();
         $row->addLabel('file', __('ZIP File'));
-        $row->addFileUpload('file')->required();
+        $row->addFileUpload('file')->required()->accepts('.zip');
 
     $sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
     $row = $form->addRow();

--- a/Free Learning/units_manage_importProcess.php
+++ b/Free Learning/units_manage_importProcess.php
@@ -1,0 +1,60 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\FileUploader;
+use Gibbon\Module\FreeLearning\UnitImporter;
+
+require_once '../../gibbon.php';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $gibbonDepartmentIDList = isset($_POST['gibbonDepartmentIDList']) ? implode(',', $_POST['gibbonDepartmentIDList']) : '';
+    $course = $_POST['course'] ?? '';
+
+    if (empty($_FILES['file'])) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $fileUploader = new FileUploader($pdo, $gibbon->session);
+    $zipFile = $fileUploader->uploadFromPost($_FILES['file']);
+
+    if (empty($zipFile)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $importer = $container->get(UnitImporter::class);
+    $importer->setDefaults($gibbonDepartmentIDList, $course);
+    $success = $importer->importFromFile($gibbon->session->get('absolutePath').'/'.$zipFile);
+
+
+    $URL .= !$success
+        ? '&return=warning1'
+        : '&return=success0';
+    header("Location: {$URL}");
+
+}

--- a/Free Learning/units_manage_importProcess.php
+++ b/Free Learning/units_manage_importProcess.php
@@ -24,6 +24,11 @@ require_once '../../gibbon.php';
 
 $URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Free Learning/units_manage.php';
 
+// Override the ini to keep this process alive
+ini_set('memory_limit', '2048M');
+ini_set('max_execution_time', 1800);
+set_time_limit(1800);
+
 if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
@@ -31,6 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
     // Proceed!
     $gibbonDepartmentIDList = isset($_POST['gibbonDepartmentIDList']) ? implode(',', $_POST['gibbonDepartmentIDList']) : '';
     $course = $_POST['course'] ?? '';
+    $override = $_POST['override'] ?? false;
 
     if (empty($_FILES['file'])) {
         $URL .= '&return=error1';
@@ -49,6 +55,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
 
     $importer = $container->get(UnitImporter::class);
     $importer->setDefaults($gibbonDepartmentIDList, $course);
+    $importer->setOverride($override == 'Y');
+
     $success = $importer->importFromFile($gibbon->session->get('absolutePath').'/'.$zipFile);
 
 

--- a/Free Learning/version.php
+++ b/Free Learning/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '5.10.13';
+$moduleVersion = '5.11.00';


### PR DESCRIPTION
This PR enables administrators to export units from one installation and import them in another. The export creates a json file of the unit data as well as extracts all the images used in the units and downloads them in a zip archive. The resulting zip file can be imported into any other system.

- It handles unit authors and prerequisites by saving them in the json data.
- It extracts images that are available locally on the server (faster) and can also download images that are served remotely via url (slower exports, but makes sure image links are less likely to break).
- The import screen enables re-associating the imported units with a different learning area or course. 
- Importing allows optionally overwriting existing units, in the case of re-importing units.

  <img width="808" alt="Screenshot 2020-10-28 at 2 44 29 PM" src="https://user-images.githubusercontent.com/897700/97401785-65140b80-192c-11eb-98f8-02d148a778fc.png">

- Adds a bulk action Export option for multiple units as well as a single Export option at the top of the unit
  <img width="854" alt="Screenshot 2020-10-28 at 2 44 42 PM" src="https://user-images.githubusercontent.com/897700/97401824-7b21cc00-192c-11eb-9fba-01fd76506702.png">
