### PR TITLE
Smartblock copy functionality change for big schools

### DIFF
--- a/Free Learning/units_manage_add.php
+++ b/Free Learning/units_manage_add.php
@@ -242,18 +242,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Free Learning/units_manage
         $blocks = [];
         $chainedTo = [];
 
-        $units = array_reduce($allBlocks->fetchAll(), function($group, $item) use (&$blocks, &$chainedTo) {
-            $group[$item['freeLearningUnitID']] = $item['unitName'];
+        if ($bigDataSchool == "N") {
+            $units = array_reduce($allBlocks->fetchAll(), function($group, $item) use (&$blocks, &$chainedTo) {
+                $group[$item['freeLearningUnitID']] = $item['unitName'];
 
-            $blocks[$item['freeLearningUnitID'].'_placeholder'] = '';
-            $blocks[$item['freeLearningUnitBlockID']] = $item['title'];
-            $chainedTo[$item['freeLearningUnitID'].'_placeholder'] = $item['freeLearningUnitID'];
-            $chainedTo[$item['freeLearningUnitBlockID']] = $item['freeLearningUnitID'];
+                $blocks[$item['freeLearningUnitID'].'_placeholder'] = '';
+                $blocks[$item['freeLearningUnitBlockID']] = $item['title'];
+                $chainedTo[$item['freeLearningUnitID'].'_placeholder'] = $item['freeLearningUnitID'];
+                $chainedTo[$item['freeLearningUnitBlockID']] = $item['freeLearningUnitID'];
 
-            return $group;
-        }, []);
+                return $group;
+            }, []);
 
-         if ($bigDataSchool == "N") {
+         
             $grid = $form->getFactory()
                 ->createGrid('selectGrid', 4);
 


### PR DESCRIPTION
In https://github.com/GibbonEdu/module-freeLearning/releases/tag/v5.22.06 you added the bigschool conditional statement for smart block copying.

The array_reduce function that ran before the condition was still taking a long time to complete. Non of the results are used outside of that if statement so I moved it inside.

On the Mos server (big school), this was an almost 10x improvement (13 seconds to 1.5) to load that page.